### PR TITLE
Add support for extra monitorv2 fields (bitdepth, color management, HDR/SDR luminance)

### DIFF
--- a/internal/apply/apply.go
+++ b/internal/apply/apply.go
@@ -248,6 +248,18 @@ func commandForOutput(name string, out profile.OutputConfig, mirrorTarget string
 	if out.SDRSaturation != 0 && out.SDRSaturation != 1.0 {
 		cmd += ",sdrsaturation," + formatFloat(out.SDRSaturation, 2)
 	}
+	if out.SDREOTF != "" && out.SDREOTF != "default" {
+		// v1 uses numeric: 0=default, 1=srgb, 2=gamma22
+		switch out.SDREOTF {
+		case "srgb":
+			cmd += ",sdr_eotf,1"
+		case "gamma22":
+			cmd += ",sdr_eotf,2"
+		}
+	}
+	if out.ICC != "" {
+		cmd += ",icc," + out.ICC
+	}
 	if mirrorTarget != "" {
 		cmd += ",mirror," + mirrorTarget
 	}
@@ -513,8 +525,23 @@ func renderMonitorV2Block(identifier string, output profile.OutputConfig, mirror
 		lines = append(lines, fmt.Sprintf("  sdr_max_luminance = %d", output.SDRMaxLuminance))
 	}
 	if output.MinLuminance != 0 || output.MaxLuminance != 0 {
-		lines = append(lines, fmt.Sprintf("  min_luminance = %d", output.MinLuminance))
+		lines = append(lines, "  min_luminance = "+formatFloat(output.MinLuminance, 3))
 		lines = append(lines, fmt.Sprintf("  max_luminance = %d", output.MaxLuminance))
+	}
+	if output.MaxAvgLuminance != 0 {
+		lines = append(lines, fmt.Sprintf("  max_avg_luminance = %d", output.MaxAvgLuminance))
+	}
+	if output.SupportsWideColor != 0 {
+		lines = append(lines, fmt.Sprintf("  supports_wide_color = %d", output.SupportsWideColor))
+	}
+	if output.SupportsHDR != 0 {
+		lines = append(lines, fmt.Sprintf("  supports_hdr = %d", output.SupportsHDR))
+	}
+	if output.SDREOTF != "" && output.SDREOTF != "default" {
+		lines = append(lines, "  sdr_eotf = "+output.SDREOTF)
+	}
+	if output.ICC != "" {
+		lines = append(lines, "  icc = "+output.ICC)
 	}
 	if mirrorTarget != "" {
 		lines = append(lines, "  mirror = "+mirrorTarget)

--- a/internal/apply/apply.go
+++ b/internal/apply/apply.go
@@ -97,16 +97,22 @@ func SnapshotCommands(monitors []hypr.Monitor) []string {
 			continue
 		}
 		out := profile.OutputConfig{
-			Enabled:   true,
-			Mode:      m.ModeString(),
-			Width:     m.Width,
-			Height:    m.Height,
-			Refresh:   m.RefreshRate,
-			X:         m.X,
-			Y:         m.Y,
-			Scale:     m.Scale,
-			VRR:       boolToVRR(m.VRR),
-			Transform: m.Transform,
+			Enabled:         true,
+			Mode:            m.ModeString(),
+			Width:           m.Width,
+			Height:          m.Height,
+			Refresh:         m.RefreshRate,
+			X:               m.X,
+			Y:               m.Y,
+			Scale:           m.Scale,
+			VRR:             int(m.VRR),
+			Transform:       m.Transform,
+			Bitdepth:        m.Bitdepth(),
+			CM:              m.ColorManagementPreset,
+			SDRBrightness:   m.SDRBrightness,
+			SDRSaturation:   m.SDRSaturation,
+			SDRMinLuminance: m.SDRMinLuminance,
+			SDRMaxLuminance: m.SDRMaxLuminance,
 		}
 		commands = append(commands, commandForOutput(m.Name, out, m.MirrorOf))
 	}
@@ -230,6 +236,18 @@ func commandForOutput(name string, out profile.OutputConfig, mirrorTarget string
 	}
 
 	cmd := fmt.Sprintf("%s,%s,%dx%d,%s,transform,%d,vrr,%d", name, mode, x, y, formatFloat(scale, 3), transform, vrr)
+	if out.Bitdepth > 0 && out.Bitdepth != 8 {
+		cmd += fmt.Sprintf(",bitdepth,%d", out.Bitdepth)
+	}
+	if out.CM != "" && out.CM != "srgb" {
+		cmd += ",cm," + out.CM
+	}
+	if out.SDRBrightness != 0 && out.SDRBrightness != 1.0 {
+		cmd += ",sdrbrightness," + formatFloat(out.SDRBrightness, 2)
+	}
+	if out.SDRSaturation != 0 && out.SDRSaturation != 1.0 {
+		cmd += ",sdrsaturation," + formatFloat(out.SDRSaturation, 2)
+	}
 	if mirrorTarget != "" {
 		cmd += ",mirror," + mirrorTarget
 	}
@@ -304,13 +322,6 @@ func shellEscape(value string) string {
 		return value
 	}
 	return "'" + strings.ReplaceAll(value, "'", "'\\''") + "'"
-}
-
-func boolToVRR(v bool) int {
-	if v {
-		return 1
-	}
-	return 0
 }
 
 func (e Engine) applyLiveCommands(ctx context.Context, commands []string) error {
@@ -456,9 +467,8 @@ func ValidateAppliedProfile(p profile.Profile, before []hypr.Monitor, after []hy
 		if applied.Transform != output.Transform {
 			return fmt.Errorf("%s transform mismatch: wanted %d, got %d", monitor.Name, output.Transform, applied.Transform)
 		}
-		if boolToVRR(applied.VRR) != output.VRR {
-			return fmt.Errorf("%s VRR mismatch: wanted %d, got %d", monitor.Name, output.VRR, boolToVRR(applied.VRR))
-		}
+		// VRR validation skipped: hyprctl reports VRR as a boolean (active
+		// or not), not the configured mode (0/1/2).
 	}
 
 	return nil
@@ -485,6 +495,26 @@ func renderMonitorV2Block(identifier string, output profile.OutputConfig, mirror
 	}
 	if output.VRR != 0 {
 		lines = append(lines, fmt.Sprintf("  vrr = %d", output.VRR))
+	}
+	if output.Bitdepth > 0 && output.Bitdepth != 8 {
+		lines = append(lines, fmt.Sprintf("  bitdepth = %d", output.Bitdepth))
+	}
+	if output.CM != "" && output.CM != "srgb" {
+		lines = append(lines, "  cm = "+output.CM)
+	}
+	if output.SDRBrightness != 0 && output.SDRBrightness != 1.0 {
+		lines = append(lines, "  sdrbrightness = "+formatFloat(output.SDRBrightness, 2))
+	}
+	if output.SDRSaturation != 0 && output.SDRSaturation != 1.0 {
+		lines = append(lines, "  sdrsaturation = "+formatFloat(output.SDRSaturation, 2))
+	}
+	if output.SDRMinLuminance != 0 || output.SDRMaxLuminance != 0 {
+		lines = append(lines, "  sdr_min_luminance = "+formatFloat(output.SDRMinLuminance, 3))
+		lines = append(lines, fmt.Sprintf("  sdr_max_luminance = %d", output.SDRMaxLuminance))
+	}
+	if output.MinLuminance != 0 || output.MaxLuminance != 0 {
+		lines = append(lines, fmt.Sprintf("  min_luminance = %d", output.MinLuminance))
+		lines = append(lines, fmt.Sprintf("  max_luminance = %d", output.MaxLuminance))
 	}
 	if mirrorTarget != "" {
 		lines = append(lines, "  mirror = "+mirrorTarget)

--- a/internal/apply/apply_test.go
+++ b/internal/apply/apply_test.go
@@ -676,6 +676,11 @@ func TestRenderMonitorV2BlockDefaultsOmitted(t *testing.T) {
 		"sdr_max_luminance",
 		"min_luminance",
 		"max_luminance",
+		"max_avg_luminance",
+		"supports_wide_color",
+		"supports_hdr",
+		"sdr_eotf",
+		"icc",
 	} {
 		if strings.Contains(rendered, unwanted) {
 			t.Fatalf("rendered config should not contain default %q:\n%s", unwanted, rendered)
@@ -725,9 +730,9 @@ func TestRenderMonitorV2BlockLuminancePairs(t *testing.T) {
 
 	t.Run("only EDID min luminance", func(t *testing.T) {
 		out := base
-		out.MinLuminance = 5
+		out.MinLuminance = 0.005
 		rendered := testRenderV2(t, []profile.OutputConfig{out}, []hypr.Monitor{mon})
-		if !strings.Contains(rendered, "min_luminance = 5") {
+		if !strings.Contains(rendered, "min_luminance = 0.005") {
 			t.Fatalf("expected min_luminance when only min is set:\n%s", rendered)
 		}
 	})
@@ -746,6 +751,8 @@ func TestCommandForOutputV1ExtraFields(t *testing.T) {
 		VRR:          2,
 		Bitdepth:     10,
 		CM:           "wide",
+		SDREOTF:      "srgb",
+		ICC:          "/usr/share/color/icc/test.icc",
 		MaxLuminance: 800,
 	}})
 
@@ -756,13 +763,12 @@ func TestCommandForOutputV1ExtraFields(t *testing.T) {
 	if len(cmds) != 1 {
 		t.Fatalf("expected 1 command, got %d", len(cmds))
 	}
-	for _, want := range []string{"vrr,2", "bitdepth,10", "cm,wide"} {
+	for _, want := range []string{"vrr,2", "bitdepth,10", "cm,wide", "sdr_eotf,1", "icc,/usr/share/color/icc/test.icc"} {
 		if !strings.Contains(cmds[0], want) {
 			t.Fatalf("v1 command missing %q: %s", want, cmds[0])
 		}
 	}
-	// Luminance fields are monitorv2-only
-	for _, unwanted := range []string{"min_luminance", "max_luminance", "sdr_min_luminance"} {
+	for _, unwanted := range []string{"min_luminance", "max_luminance", "sdr_min_luminance", "max_avg_luminance", "supports_wide_color", "supports_hdr"} {
 		if strings.Contains(cmds[0], unwanted) {
 			t.Fatalf("v1 command should not contain %q: %s", unwanted, cmds[0])
 		}
@@ -825,5 +831,44 @@ func TestProfileValidateBitdepth(t *testing.T) {
 		if err := p.Validate(); err == nil {
 			t.Errorf("bitdepth %d should be invalid", bd)
 		}
+	}
+}
+
+func TestRenderMonitorV2BlockNewEDIDFields(t *testing.T) {
+	mon := testMonitor("DP-1", "Dell U2720Q", "Dell", "U2720Q", "A1")
+	rendered := testRenderV2(t, []profile.OutputConfig{{
+		Key: mon.HardwareKey(), Name: "DP-1", Enabled: true,
+		Width: 2560, Height: 1440, Refresh: 144, Scale: 1,
+		SupportsWideColor: -1,
+		SupportsHDR:       1,
+		MaxAvgLuminance:   350,
+		SDREOTF:           "gamma22",
+		ICC:               "/usr/share/color/icc/test.icc",
+	}}, []hypr.Monitor{mon})
+
+	for _, want := range []string{
+		"supports_wide_color = -1",
+		"supports_hdr = 1",
+		"max_avg_luminance = 350",
+		"sdr_eotf = gamma22",
+		"icc = /usr/share/color/icc/test.icc",
+	} {
+		if !strings.Contains(rendered, want) {
+			t.Fatalf("missing %q:\n%s", want, rendered)
+		}
+	}
+}
+
+func TestRenderMonitorV2MinLuminanceFloat(t *testing.T) {
+	mon := testMonitor("DP-1", "Dell U2720Q", "Dell", "U2720Q", "A1")
+	rendered := testRenderV2(t, []profile.OutputConfig{{
+		Key: mon.HardwareKey(), Name: "DP-1", Enabled: true,
+		Width: 2560, Height: 1440, Refresh: 144, Scale: 1,
+		MinLuminance: 0.005,
+		MaxLuminance: 800,
+	}}, []hypr.Monitor{mon})
+
+	if !strings.Contains(rendered, "min_luminance = 0.005") {
+		t.Fatalf("expected float min_luminance:\n%s", rendered)
 	}
 }

--- a/internal/apply/apply_test.go
+++ b/internal/apply/apply_test.go
@@ -2,6 +2,7 @@ package apply
 
 import (
 	"context"
+	"encoding/json"
 	"os"
 	"path/filepath"
 	"strings"
@@ -185,6 +186,8 @@ func TestRenderHyprlandConfigUsesMonitorV2WithWorkspaceRules(t *testing.T) {
 		Scale:     1.33,
 		VRR:       1,
 		Transform: 0,
+		Bitdepth:  10,
+		CM:        "wide",
 	}})
 	p.Workspaces = profile.WorkspaceSettings{
 		Enabled:       true,
@@ -206,6 +209,8 @@ func TestRenderHyprlandConfigUsesMonitorV2WithWorkspaceRules(t *testing.T) {
 		"position = 3720x951",
 		"scale = 1.33",
 		"vrr = 1",
+		"bitdepth = 10",
+		"cm = wide",
 		"workspace = 1, monitor:desc:Microstep MPG321UR-QD, default:true, persistent:true",
 	} {
 		if !strings.Contains(rendered, want) {
@@ -499,7 +504,7 @@ exit 1
 	}
 
 	monitors := []hypr.Monitor{
-		{Name: "DP-1", Description: "Microstep MPG321UR-QD", Make: "Microstep", Model: "MPG321UR-QD", Serial: "A1", Width: 3840, Height: 2160, RefreshRate: 143.99, Scale: 1, VRR: true},
+		{Name: "DP-1", Description: "Microstep MPG321UR-QD", Make: "Microstep", Model: "MPG321UR-QD", Serial: "A1", Width: 3840, Height: 2160, RefreshRate: 143.99, Scale: 1, VRR: 1},
 		{Name: "eDP-1", Description: "Samsung Display Corp. ATNA60CL10-0", Make: "Samsung Display Corp.", Model: "ATNA60CL10-0", Serial: "B2", Width: 2880, Height: 1800, RefreshRate: 120, X: 3840, Scale: 1},
 	}
 	p := profile.New("desk", []profile.OutputConfig{
@@ -543,6 +548,282 @@ exit 1
 	} {
 		if !strings.Contains(log, want) {
 			t.Fatalf("expected hyprctl log to contain %q, got:\n%s", want, log)
+		}
+	}
+}
+
+func TestVRRModeUnmarshal(t *testing.T) {
+	tests := []struct {
+		json string
+		want int
+	}{
+		{`{"vrr": false}`, 0},
+		{`{"vrr": true}`, 1},
+		{`{"vrr": 0}`, 0},
+		{`{"vrr": 1}`, 1},
+		{`{"vrr": 2}`, 2},
+	}
+	for _, tt := range tests {
+		var m hypr.Monitor
+		if err := json.Unmarshal([]byte(tt.json), &m); err != nil {
+			t.Errorf("Unmarshal(%s) error: %v", tt.json, err)
+			continue
+		}
+		if got := int(m.VRR); got != tt.want {
+			t.Errorf("Unmarshal(%s).VRR = %d, want %d", tt.json, got, tt.want)
+		}
+	}
+}
+
+func TestMonitorBitdepthParsing(t *testing.T) {
+	tests := []struct {
+		format string
+		want   int
+	}{
+		{"XBGR2101010", 10},
+		{"XRGB2101010", 10},
+		{"ABGR2101010", 10},
+		{"XBGR16161616F", 16},
+		{"XRGB8888", 8},
+		{"", 8},
+	}
+	for _, tt := range tests {
+		m := hypr.Monitor{CurrentFormat: tt.format}
+		if got := m.Bitdepth(); got != tt.want {
+			t.Errorf("Bitdepth(%q) = %d, want %d", tt.format, got, tt.want)
+		}
+	}
+}
+
+func testMonitor(name, desc, make_, model, serial string) hypr.Monitor {
+	return hypr.Monitor{Name: name, Description: desc, Make: make_, Model: model, Serial: serial}
+}
+
+func testRenderV2(t *testing.T, outputs []profile.OutputConfig, monitors []hypr.Monitor) string {
+	t.Helper()
+	p := profile.New(t.Name(), outputs)
+	rendered, err := RenderHyprlandConfig(p, monitors, true)
+	if err != nil {
+		t.Fatalf("unexpected render error: %v", err)
+	}
+	return rendered
+}
+
+func TestRenderMonitorV2BlockWithExtraFields(t *testing.T) {
+	mon := testMonitor("HDMI-A-1", "LG Electronics LG TV SSCR2 0x01010101", "LG Electronics", "LG TV SSCR2", "0x01010101")
+	rendered := testRenderV2(t, []profile.OutputConfig{{
+		Key:             mon.HardwareKey(),
+		Name:            "HDMI-A-1",
+		Enabled:         true,
+		Width:           3840,
+		Height:          2160,
+		Refresh:         143.99,
+		Scale:           1.25,
+		VRR:             2,
+		Bitdepth:        10,
+		CM:              "wide",
+		SDRBrightness:   1.2,
+		SDRSaturation:   0.98,
+		SDRMinLuminance: 0.005,
+		SDRMaxLuminance: 400,
+		MinLuminance:    0,
+		MaxLuminance:    800,
+	}}, []hypr.Monitor{mon})
+
+	for _, want := range []string{
+		"vrr = 2",
+		"bitdepth = 10",
+		"cm = wide",
+		"sdrbrightness = 1.2",
+		"sdrsaturation = 0.98",
+		"sdr_min_luminance = 0.005",
+		"sdr_max_luminance = 400",
+		"min_luminance = 0",
+		"max_luminance = 800",
+	} {
+		if !strings.Contains(rendered, want) {
+			t.Fatalf("rendered config missing %q:\n%s", want, rendered)
+		}
+	}
+	if strings.Contains(rendered, "transform =") {
+		t.Fatalf("rendered config should not contain default transform:\n%s", rendered)
+	}
+}
+
+func TestRenderMonitorV2BlockDefaultsOmitted(t *testing.T) {
+	mon := testMonitor("DP-1", "Dell U2720Q", "Dell", "U2720Q", "A1")
+	rendered := testRenderV2(t, []profile.OutputConfig{{
+		Key:           mon.HardwareKey(),
+		Name:          "DP-1",
+		Enabled:       true,
+		Width:         2560,
+		Height:        1440,
+		Refresh:       60,
+		Scale:         1,
+		Bitdepth:      8,
+		CM:            "srgb",
+		SDRBrightness: 1.0,
+		SDRSaturation: 1.0,
+	}}, []hypr.Monitor{mon})
+
+	for _, unwanted := range []string{
+		"bitdepth",
+		"cm =",
+		"vrr",
+		"sdrbrightness",
+		"sdrsaturation",
+		"sdr_min_luminance",
+		"sdr_max_luminance",
+		"min_luminance",
+		"max_luminance",
+	} {
+		if strings.Contains(rendered, unwanted) {
+			t.Fatalf("rendered config should not contain default %q:\n%s", unwanted, rendered)
+		}
+	}
+}
+
+func TestRenderMonitorV2BlockLuminancePairs(t *testing.T) {
+	mon := testMonitor("DP-1", "Dell U2720Q", "Dell", "U2720Q", "A1")
+	base := profile.OutputConfig{
+		Key: mon.HardwareKey(), Name: "DP-1", Enabled: true,
+		Width: 3840, Height: 2160, Refresh: 144, Scale: 1.25,
+	}
+
+	t.Run("both EDID luminance", func(t *testing.T) {
+		out := base
+		out.MinLuminance = 0
+		out.MaxLuminance = 800
+		rendered := testRenderV2(t, []profile.OutputConfig{out}, []hypr.Monitor{mon})
+		for _, want := range []string{"min_luminance = 0", "max_luminance = 800"} {
+			if !strings.Contains(rendered, want) {
+				t.Fatalf("missing %q:\n%s", want, rendered)
+			}
+		}
+	})
+
+	t.Run("both SDR luminance", func(t *testing.T) {
+		out := base
+		out.SDRMinLuminance = 0.005
+		out.SDRMaxLuminance = 400
+		rendered := testRenderV2(t, []profile.OutputConfig{out}, []hypr.Monitor{mon})
+		for _, want := range []string{"sdr_min_luminance = 0.005", "sdr_max_luminance = 400"} {
+			if !strings.Contains(rendered, want) {
+				t.Fatalf("missing %q:\n%s", want, rendered)
+			}
+		}
+	})
+
+	t.Run("only SDR min luminance", func(t *testing.T) {
+		out := base
+		out.SDRMinLuminance = 0.005
+		rendered := testRenderV2(t, []profile.OutputConfig{out}, []hypr.Monitor{mon})
+		if !strings.Contains(rendered, "sdr_min_luminance = 0.005") {
+			t.Fatalf("expected sdr_min_luminance when only min is set:\n%s", rendered)
+		}
+	})
+
+	t.Run("only EDID min luminance", func(t *testing.T) {
+		out := base
+		out.MinLuminance = 5
+		rendered := testRenderV2(t, []profile.OutputConfig{out}, []hypr.Monitor{mon})
+		if !strings.Contains(rendered, "min_luminance = 5") {
+			t.Fatalf("expected min_luminance when only min is set:\n%s", rendered)
+		}
+	})
+}
+
+func TestCommandForOutputV1ExtraFields(t *testing.T) {
+	mon := testMonitor("DP-1", "", "Dell", "U2720Q", "A1")
+	p := profile.New("v1", []profile.OutputConfig{{
+		Key:          mon.HardwareKey(),
+		Name:         "DP-1",
+		Enabled:      true,
+		Width:        2560,
+		Height:       1440,
+		Refresh:      144,
+		Scale:        1,
+		VRR:          2,
+		Bitdepth:     10,
+		CM:           "wide",
+		MaxLuminance: 800,
+	}})
+
+	cmds, err := CommandsForProfile(p, []hypr.Monitor{mon})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(cmds) != 1 {
+		t.Fatalf("expected 1 command, got %d", len(cmds))
+	}
+	for _, want := range []string{"vrr,2", "bitdepth,10", "cm,wide"} {
+		if !strings.Contains(cmds[0], want) {
+			t.Fatalf("v1 command missing %q: %s", want, cmds[0])
+		}
+	}
+	// Luminance fields are monitorv2-only
+	for _, unwanted := range []string{"min_luminance", "max_luminance", "sdr_min_luminance"} {
+		if strings.Contains(cmds[0], unwanted) {
+			t.Fatalf("v1 command should not contain %q: %s", unwanted, cmds[0])
+		}
+	}
+}
+
+func TestFromStateCopiesExtraFields(t *testing.T) {
+	monitors := []hypr.Monitor{{
+		Name: "HDMI-A-1", Make: "LG", Model: "TV", Serial: "123",
+		Width: 3840, Height: 2160, RefreshRate: 144, Scale: 1.25,
+		VRR: 1, CurrentFormat: "XBGR2101010",
+		ColorManagementPreset: "wide",
+		SDRBrightness:         1.2,
+		SDRSaturation:         0.98,
+		SDRMinLuminance:       0.005,
+		SDRMaxLuminance:       400,
+	}}
+	p := profile.FromMonitors("test", monitors)
+
+	out := p.Outputs[0]
+	if out.VRR != 1 {
+		t.Errorf("VRR = %d, want 1", out.VRR)
+	}
+	if out.Bitdepth != 10 {
+		t.Errorf("Bitdepth = %d, want 10", out.Bitdepth)
+	}
+	if out.CM != "wide" {
+		t.Errorf("CM = %q, want %q", out.CM, "wide")
+	}
+	if out.SDRBrightness != 1.2 {
+		t.Errorf("SDRBrightness = %f, want 1.2", out.SDRBrightness)
+	}
+	if out.SDRSaturation != 0.98 {
+		t.Errorf("SDRSaturation = %f, want 0.98", out.SDRSaturation)
+	}
+	if out.SDRMinLuminance != 0.005 {
+		t.Errorf("SDRMinLuminance = %f, want 0.005", out.SDRMinLuminance)
+	}
+	if out.SDRMaxLuminance != 400 {
+		t.Errorf("SDRMaxLuminance = %d, want 400", out.SDRMaxLuminance)
+	}
+}
+
+func TestProfileValidateBitdepth(t *testing.T) {
+	valid := []int{0, 8, 10, 16}
+	for _, bd := range valid {
+		p := profile.New("test", []profile.OutputConfig{{
+			Key: "test", Enabled: true, Scale: 1, Bitdepth: bd,
+		}})
+		if err := p.Validate(); err != nil {
+			t.Errorf("bitdepth %d should be valid, got: %v", bd, err)
+		}
+	}
+
+	invalid := []int{4, 12, 24, -1}
+	for _, bd := range invalid {
+		p := profile.New("test", []profile.OutputConfig{{
+			Key: "test", Enabled: true, Scale: 1, Bitdepth: bd,
+		}})
+		if err := p.Validate(); err == nil {
+			t.Errorf("bitdepth %d should be invalid", bd)
 		}
 	}
 }

--- a/internal/hypr/monitor.go
+++ b/internal/hypr/monitor.go
@@ -1,11 +1,34 @@
 package hypr
 
 import (
+	"encoding/json"
 	"fmt"
 	"math"
 	"sort"
 	"strings"
 )
+
+// VRRMode handles hyprctl reporting VRR as either a bool or an int.
+// bool: false=0, true=1. int: 0=off, 1=on, 2=fullscreen-only.
+type VRRMode int
+
+func (v *VRRMode) UnmarshalJSON(data []byte) error {
+	var i int
+	if err := json.Unmarshal(data, &i); err == nil {
+		*v = VRRMode(i)
+		return nil
+	}
+	var b bool
+	if err := json.Unmarshal(data, &b); err == nil {
+		if b {
+			*v = 1
+		} else {
+			*v = 0
+		}
+		return nil
+	}
+	return fmt.Errorf("VRR: expected bool or int, got %s", data)
+}
 
 type Workspace struct {
 	ID   int    `json:"id"`
@@ -29,28 +52,45 @@ type WorkspaceRule struct {
 }
 
 type Monitor struct {
-	ID              int       `json:"id"`
-	Name            string    `json:"name"`
-	Description     string    `json:"description"`
-	Make            string    `json:"make"`
-	Model           string    `json:"model"`
-	Serial          string    `json:"serial"`
-	Width           int       `json:"width"`
-	Height          int       `json:"height"`
-	PhysicalWidth   int       `json:"physicalWidth"`
-	PhysicalHeight  int       `json:"physicalHeight"`
-	RefreshRate     float64   `json:"refreshRate"`
-	X               int       `json:"x"`
-	Y               int       `json:"y"`
-	Scale           float64   `json:"scale"`
-	Transform       int       `json:"transform"`
-	Focused         bool      `json:"focused"`
-	DPMSStatus      bool      `json:"dpmsStatus"`
-	VRR             bool      `json:"vrr"`
-	Disabled        bool      `json:"disabled"`
-	MirrorOf        string    `json:"mirrorOf"`
-	AvailableModes  []string  `json:"availableModes"`
-	ActiveWorkspace Workspace `json:"activeWorkspace"`
+	ID                    int       `json:"id"`
+	Name                  string    `json:"name"`
+	Description           string    `json:"description"`
+	Make                  string    `json:"make"`
+	Model                 string    `json:"model"`
+	Serial                string    `json:"serial"`
+	Width                 int       `json:"width"`
+	Height                int       `json:"height"`
+	PhysicalWidth         int       `json:"physicalWidth"`
+	PhysicalHeight        int       `json:"physicalHeight"`
+	RefreshRate           float64   `json:"refreshRate"`
+	X                     int       `json:"x"`
+	Y                     int       `json:"y"`
+	Scale                 float64   `json:"scale"`
+	Transform             int       `json:"transform"`
+	Focused               bool      `json:"focused"`
+	DPMSStatus            bool      `json:"dpmsStatus"`
+	VRR                   VRRMode   `json:"vrr"`
+	Disabled              bool      `json:"disabled"`
+	MirrorOf              string    `json:"mirrorOf"`
+	CurrentFormat         string    `json:"currentFormat"`
+	ColorManagementPreset string    `json:"colorManagementPreset"`
+	SDRBrightness         float64   `json:"sdrBrightness"`
+	SDRSaturation         float64   `json:"sdrSaturation"`
+	SDRMinLuminance       float64   `json:"sdrMinLuminance"`
+	SDRMaxLuminance       int       `json:"sdrMaxLuminance"`
+	AvailableModes        []string  `json:"availableModes"`
+	ActiveWorkspace       Workspace `json:"activeWorkspace"`
+}
+
+func (m Monitor) Bitdepth() int {
+	switch m.CurrentFormat {
+	case "XBGR2101010", "XRGB2101010", "ABGR2101010", "ARGB2101010":
+		return 10
+	case "XBGR16161616F", "XRGB16161616F", "ABGR16161616F", "ARGB16161616F":
+		return 16
+	default:
+		return 8
+	}
 }
 
 func (m Monitor) IsInternal() bool {

--- a/internal/profile/match.go
+++ b/internal/profile/match.go
@@ -174,6 +174,14 @@ func outputConfigsShareEffectiveState(a, b OutputConfig) bool {
 		clampStateScale(a.Scale) == clampStateScale(b.Scale) &&
 		a.Transform == b.Transform &&
 		a.VRR == b.VRR &&
+		a.Bitdepth == b.Bitdepth &&
+		a.CM == b.CM &&
+		a.SDRBrightness == b.SDRBrightness &&
+		a.SDRSaturation == b.SDRSaturation &&
+		a.SDRMinLuminance == b.SDRMinLuminance &&
+		a.SDRMaxLuminance == b.SDRMaxLuminance &&
+		a.MinLuminance == b.MinLuminance &&
+		a.MaxLuminance == b.MaxLuminance &&
 		firstNonEmpty(a.MirrorOf, "") == firstNonEmpty(b.MirrorOf, "")
 }
 
@@ -204,7 +212,7 @@ func MonitorStateHash(monitors []hypr.Monitor) string {
 
 func monitorStateSignature(m hypr.Monitor) string {
 	return fmt.Sprintf(
-		"%s|%s|disabled=%t|%dx%d@%.2f|%dx%d|scale=%s|transform=%d|vrr=%d",
+		"%s|%s|disabled=%t|%dx%d@%.2f|%dx%d|scale=%s|transform=%d|vrr=%d|fmt=%s|cm=%s|sdrbr=%.2f|sdrsat=%.2f|sdrmin=%.3f|sdrmax=%d",
 		m.HardwareKey(),
 		strings.ToLower(strings.TrimSpace(m.Name)),
 		m.Disabled,
@@ -216,6 +224,12 @@ func monitorStateSignature(m hypr.Monitor) string {
 		strconv.FormatFloat(clampStateScale(m.Scale), 'f', 3, 64),
 		m.Transform,
 		m.VRR,
+		m.CurrentFormat,
+		m.ColorManagementPreset,
+		m.SDRBrightness,
+		m.SDRSaturation,
+		m.SDRMinLuminance,
+		m.SDRMaxLuminance,
 	)
 }
 

--- a/internal/profile/match.go
+++ b/internal/profile/match.go
@@ -168,20 +168,18 @@ func outputConfigsShareEffectiveState(a, b OutputConfig) bool {
 		return true
 	}
 
+	// Only compare fields that hyprctl accurately reports. Config-only
+	// fields (VRR, Bitdepth, CM, EDID luminance/overrides, SDR EOTF, ICC)
+	// are excluded because FromState cannot populate them from live state.
 	return a.NormalizedMode() == b.NormalizedMode() &&
 		a.X == b.X &&
 		a.Y == b.Y &&
 		clampStateScale(a.Scale) == clampStateScale(b.Scale) &&
 		a.Transform == b.Transform &&
-		a.VRR == b.VRR &&
-		a.Bitdepth == b.Bitdepth &&
-		a.CM == b.CM &&
 		a.SDRBrightness == b.SDRBrightness &&
 		a.SDRSaturation == b.SDRSaturation &&
 		a.SDRMinLuminance == b.SDRMinLuminance &&
 		a.SDRMaxLuminance == b.SDRMaxLuminance &&
-		a.MinLuminance == b.MinLuminance &&
-		a.MaxLuminance == b.MaxLuminance &&
 		firstNonEmpty(a.MirrorOf, "") == firstNonEmpty(b.MirrorOf, "")
 }
 

--- a/internal/profile/match.go
+++ b/internal/profile/match.go
@@ -204,7 +204,7 @@ func MonitorStateHash(monitors []hypr.Monitor) string {
 
 func monitorStateSignature(m hypr.Monitor) string {
 	return fmt.Sprintf(
-		"%s|%s|disabled=%t|%dx%d@%.2f|%dx%d|scale=%s|transform=%d|vrr=%t",
+		"%s|%s|disabled=%t|%dx%d@%.2f|%dx%d|scale=%s|transform=%d|vrr=%d",
 		m.HardwareKey(),
 		strings.ToLower(strings.TrimSpace(m.Name)),
 		m.Disabled,

--- a/internal/profile/match.go
+++ b/internal/profile/match.go
@@ -169,13 +169,15 @@ func outputConfigsShareEffectiveState(a, b OutputConfig) bool {
 	}
 
 	// Only compare fields that hyprctl accurately reports. Config-only
-	// fields (VRR, Bitdepth, CM, EDID luminance/overrides, SDR EOTF, ICC)
-	// are excluded because FromState cannot populate them from live state.
+	// fields (VRR mode, EDID luminance/overrides, SDR EOTF, ICC) are
+	// excluded because FromState cannot populate them from live state.
 	return a.NormalizedMode() == b.NormalizedMode() &&
 		a.X == b.X &&
 		a.Y == b.Y &&
 		clampStateScale(a.Scale) == clampStateScale(b.Scale) &&
 		a.Transform == b.Transform &&
+		a.Bitdepth == b.Bitdepth &&
+		a.CM == b.CM &&
 		a.SDRBrightness == b.SDRBrightness &&
 		a.SDRSaturation == b.SDRSaturation &&
 		a.SDRMinLuminance == b.SDRMinLuminance &&

--- a/internal/profile/match_test.go
+++ b/internal/profile/match_test.go
@@ -200,3 +200,31 @@ func TestExactStateMatchRejectsAmbiguousDuplicateProfiles(t *testing.T) {
 		t.Fatal("expected ambiguous exact profile matches to be rejected")
 	}
 }
+
+func TestExactStateMatchIgnoresConfigOnlyFields(t *testing.T) {
+	monitors := []hypr.Monitor{{
+		Name: "DP-1", Make: "Dell", Model: "U2720Q", Serial: "A1",
+		Width: 2560, Height: 1440, RefreshRate: 144,
+		Scale: 1,
+	}}
+
+	saved := FromState("desk", monitors, nil)
+	saved.Outputs[0].VRR = 2
+	saved.Outputs[0].Bitdepth = 10
+	saved.Outputs[0].CM = "wide"
+	saved.Outputs[0].MinLuminance = 0.005
+	saved.Outputs[0].MaxLuminance = 800
+	saved.Outputs[0].SupportsWideColor = 1
+	saved.Outputs[0].SupportsHDR = 1
+	saved.Outputs[0].MaxAvgLuminance = 500
+	saved.Outputs[0].SDREOTF = "gamma22"
+	saved.Outputs[0].ICC = "/path/to/icc"
+
+	got, ok := ExactStateMatch([]Profile{saved}, monitors, nil)
+	if !ok {
+		t.Fatal("expected ExactStateMatch to succeed despite config-only field differences")
+	}
+	if got.Name != "desk" {
+		t.Fatalf("expected desk, got %q", got.Name)
+	}
+}

--- a/internal/profile/match_test.go
+++ b/internal/profile/match_test.go
@@ -210,8 +210,6 @@ func TestExactStateMatchIgnoresConfigOnlyFields(t *testing.T) {
 
 	saved := FromState("desk", monitors, nil)
 	saved.Outputs[0].VRR = 2
-	saved.Outputs[0].Bitdepth = 10
-	saved.Outputs[0].CM = "wide"
 	saved.Outputs[0].MinLuminance = 0.005
 	saved.Outputs[0].MaxLuminance = 800
 	saved.Outputs[0].SupportsWideColor = 1
@@ -226,5 +224,21 @@ func TestExactStateMatchIgnoresConfigOnlyFields(t *testing.T) {
 	}
 	if got.Name != "desk" {
 		t.Fatalf("expected desk, got %q", got.Name)
+	}
+}
+
+func TestExactStateMatchDetectsBitdepthAndCMDifference(t *testing.T) {
+	monitors := []hypr.Monitor{{
+		Name: "DP-1", Make: "Dell", Model: "U2720Q", Serial: "A1",
+		Width: 2560, Height: 1440, RefreshRate: 144,
+		Scale: 1, CurrentFormat: "XRGB8888", ColorManagementPreset: "srgb",
+	}}
+
+	saved := FromState("desk", monitors, nil)
+	saved.Outputs[0].Bitdepth = 10
+	saved.Outputs[0].CM = "wide"
+
+	if _, ok := ExactStateMatch([]Profile{saved}, monitors, nil); ok {
+		t.Fatal("expected ExactStateMatch to fail when Bitdepth and CM differ from live state")
 	}
 }

--- a/internal/profile/types.go
+++ b/internal/profile/types.go
@@ -10,31 +10,36 @@ import (
 )
 
 type OutputConfig struct {
-	Key             string  `json:"key"`
-	MatchKey        string  `json:"match_key,omitempty"`
-	Name            string  `json:"name"`
-	Make            string  `json:"make,omitempty"`
-	Model           string  `json:"model,omitempty"`
-	Serial          string  `json:"serial,omitempty"`
-	Enabled         bool    `json:"enabled"`
-	Mode            string  `json:"mode,omitempty"`
-	Width           int     `json:"width"`
-	Height          int     `json:"height"`
-	Refresh         float64 `json:"refresh"`
-	X               int     `json:"x"`
-	Y               int     `json:"y"`
-	Scale           float64 `json:"scale"`
-	VRR             int     `json:"vrr,omitempty"`
-	Transform       int     `json:"transform"`
-	MirrorOf        string  `json:"mirror_of,omitempty"`
-	Bitdepth        int     `json:"bitdepth,omitempty"`
-	CM              string  `json:"cm,omitempty"`
-	SDRBrightness   float64 `json:"sdr_brightness,omitempty"`
-	SDRSaturation   float64 `json:"sdr_saturation,omitempty"`
-	SDRMinLuminance float64 `json:"sdr_min_luminance"`
-	SDRMaxLuminance int     `json:"sdr_max_luminance,omitempty"`
-	MinLuminance    int     `json:"min_luminance"`
-	MaxLuminance    int     `json:"max_luminance,omitempty"`
+	Key               string  `json:"key"`
+	MatchKey          string  `json:"match_key,omitempty"`
+	Name              string  `json:"name"`
+	Make              string  `json:"make,omitempty"`
+	Model             string  `json:"model,omitempty"`
+	Serial            string  `json:"serial,omitempty"`
+	Enabled           bool    `json:"enabled"`
+	Mode              string  `json:"mode,omitempty"`
+	Width             int     `json:"width"`
+	Height            int     `json:"height"`
+	Refresh           float64 `json:"refresh"`
+	X                 int     `json:"x"`
+	Y                 int     `json:"y"`
+	Scale             float64 `json:"scale"`
+	VRR               int     `json:"vrr,omitempty"`
+	Transform         int     `json:"transform"`
+	MirrorOf          string  `json:"mirror_of,omitempty"`
+	Bitdepth          int     `json:"bitdepth,omitempty"`
+	CM                string  `json:"cm,omitempty"`
+	SDRBrightness     float64 `json:"sdr_brightness,omitempty"`
+	SDRSaturation     float64 `json:"sdr_saturation,omitempty"`
+	SDRMinLuminance   float64 `json:"sdr_min_luminance"`
+	SDRMaxLuminance   int     `json:"sdr_max_luminance,omitempty"`
+	MinLuminance      float64 `json:"min_luminance"`
+	MaxLuminance      int     `json:"max_luminance,omitempty"`
+	SupportsWideColor int     `json:"supports_wide_color,omitempty"`
+	SupportsHDR       int     `json:"supports_hdr,omitempty"`
+	MaxAvgLuminance   int     `json:"max_avg_luminance,omitempty"`
+	SDREOTF           string  `json:"sdr_eotf,omitempty"`
+	ICC               string  `json:"icc,omitempty"`
 }
 
 type WorkspaceStrategy string
@@ -217,4 +222,3 @@ func (p *Profile) Normalize() {
 	p.normalizeIdentityRefs()
 	p.SortOutputs()
 }
-

--- a/internal/profile/types.go
+++ b/internal/profile/types.go
@@ -10,23 +10,31 @@ import (
 )
 
 type OutputConfig struct {
-	Key       string  `json:"key"`
-	MatchKey  string  `json:"match_key,omitempty"`
-	Name      string  `json:"name"`
-	Make      string  `json:"make,omitempty"`
-	Model     string  `json:"model,omitempty"`
-	Serial    string  `json:"serial,omitempty"`
-	Enabled   bool    `json:"enabled"`
-	Mode      string  `json:"mode,omitempty"`
-	Width     int     `json:"width"`
-	Height    int     `json:"height"`
-	Refresh   float64 `json:"refresh"`
-	X         int     `json:"x"`
-	Y         int     `json:"y"`
-	Scale     float64 `json:"scale"`
-	VRR       int     `json:"vrr,omitempty"`
-	Transform int     `json:"transform"`
-	MirrorOf  string  `json:"mirror_of,omitempty"`
+	Key             string  `json:"key"`
+	MatchKey        string  `json:"match_key,omitempty"`
+	Name            string  `json:"name"`
+	Make            string  `json:"make,omitempty"`
+	Model           string  `json:"model,omitempty"`
+	Serial          string  `json:"serial,omitempty"`
+	Enabled         bool    `json:"enabled"`
+	Mode            string  `json:"mode,omitempty"`
+	Width           int     `json:"width"`
+	Height          int     `json:"height"`
+	Refresh         float64 `json:"refresh"`
+	X               int     `json:"x"`
+	Y               int     `json:"y"`
+	Scale           float64 `json:"scale"`
+	VRR             int     `json:"vrr,omitempty"`
+	Transform       int     `json:"transform"`
+	MirrorOf        string  `json:"mirror_of,omitempty"`
+	Bitdepth        int     `json:"bitdepth,omitempty"`
+	CM              string  `json:"cm,omitempty"`
+	SDRBrightness   float64 `json:"sdr_brightness,omitempty"`
+	SDRSaturation   float64 `json:"sdr_saturation,omitempty"`
+	SDRMinLuminance float64 `json:"sdr_min_luminance"`
+	SDRMaxLuminance int     `json:"sdr_max_luminance,omitempty"`
+	MinLuminance    int     `json:"min_luminance"`
+	MaxLuminance    int     `json:"max_luminance,omitempty"`
 }
 
 type WorkspaceStrategy string
@@ -93,23 +101,29 @@ func FromState(name string, monitors []hypr.Monitor, rules []hypr.WorkspaceRule)
 			mirrorOf = nameToKey[m.MirrorOf]
 		}
 		outputs = append(outputs, OutputConfig{
-			Key:       hypr.MonitorOutputKey(m, matchCounts),
-			MatchKey:  m.HardwareKey(),
-			Name:      m.Name,
-			Make:      m.Make,
-			Model:     m.Model,
-			Serial:    m.Serial,
-			Enabled:   !m.Disabled,
-			Mode:      m.ModeString(),
-			Width:     m.Width,
-			Height:    m.Height,
-			Refresh:   m.RefreshRate,
-			X:         m.X,
-			Y:         m.Y,
-			Scale:     m.Scale,
-			VRR:       boolToVRR(m.VRR),
-			Transform: m.Transform,
-			MirrorOf:  mirrorOf,
+			Key:             hypr.MonitorOutputKey(m, matchCounts),
+			MatchKey:        m.HardwareKey(),
+			Name:            m.Name,
+			Make:            m.Make,
+			Model:           m.Model,
+			Serial:          m.Serial,
+			Enabled:         !m.Disabled,
+			Mode:            m.ModeString(),
+			Width:           m.Width,
+			Height:          m.Height,
+			Refresh:         m.RefreshRate,
+			X:               m.X,
+			Y:               m.Y,
+			Scale:           m.Scale,
+			VRR:             int(m.VRR),
+			Transform:       m.Transform,
+			MirrorOf:        mirrorOf,
+			Bitdepth:        m.Bitdepth(),
+			CM:              m.ColorManagementPreset,
+			SDRBrightness:   m.SDRBrightness,
+			SDRSaturation:   m.SDRSaturation,
+			SDRMinLuminance: m.SDRMinLuminance,
+			SDRMaxLuminance: m.SDRMaxLuminance,
 		})
 	}
 	p := New(name, outputs)
@@ -148,6 +162,9 @@ func (p Profile) Validate() error {
 		}
 		if out.VRR < 0 || out.VRR > 2 {
 			return fmt.Errorf("output %d has invalid VRR mode", i)
+		}
+		if out.Bitdepth != 0 && out.Bitdepth != 8 && out.Bitdepth != 10 && out.Bitdepth != 16 {
+			return fmt.Errorf("output %d has invalid bitdepth %d", i, out.Bitdepth)
 		}
 	}
 	if err := p.Workspaces.Validate(); err != nil {
@@ -201,9 +218,3 @@ func (p *Profile) Normalize() {
 	p.SortOutputs()
 }
 
-func boolToVRR(v bool) int {
-	if v {
-		return 1
-	}
-	return 0
-}

--- a/internal/tui/footer.go
+++ b/internal/tui/footer.go
@@ -39,7 +39,7 @@ type footerLayout struct {
 func (m Model) footerHelpText() string {
 	switch m.tab {
 	case tabLayout:
-		return "`drag/arrows` move | `[ ]` cycle monitors | `Enter` edit | `Tab` pane | `a` apply | `s` save | `r` reset"
+		return "`drag/arrows` move | `[ ]` cycle | `Enter` edit | `Tab` pane | `x` adv | `a` apply | `s` save | `r` reset"
 	case tabProfiles:
 		return "`Enter` load | `a` apply | `d` delete | `s` save"
 	case tabWorkspaces:
@@ -256,7 +256,7 @@ func (m Model) decorateFooterBar(footer string) string {
 	// Status badge
 	unsaved := m.unsavedLabel()
 	styled = strings.Replace(styled, unsaved, m.unsavedBadge(), 1)
-	
+
 	// Style the layout overlap error
 	if m.layoutErr != nil {
 		errStr := m.layoutErr.Error()

--- a/internal/tui/footer.go
+++ b/internal/tui/footer.go
@@ -39,7 +39,7 @@ type footerLayout struct {
 func (m Model) footerHelpText() string {
 	switch m.tab {
 	case tabLayout:
-		return "`drag/arrows` move | `[ ]` cycle | `Enter` edit | `Tab` pane | `x` adv | `a` apply | `s` save | `r` reset"
+		return "`drag/arrows` move | `[ ]` cycle monitors | `Enter` edit | `Tab` pane | `a` apply | `s` save | `r` reset"
 	case tabProfiles:
 		return "`Enter` load | `a` apply | `d` delete | `s` save"
 	case tabWorkspaces:

--- a/internal/tui/interaction.go
+++ b/internal/tui/interaction.go
@@ -1040,8 +1040,9 @@ func (m *Model) updateLayoutMouse(msg tea.MouseMsg) (tea.Model, tea.Cmd) {
 	}
 
 	if inspectorRect.contains(msg.X, msg.Y) {
+		wasFocused := m.layoutFocus == layoutFocusInspector && m.tab == tabLayout
 		m.layoutFocus = layoutFocusInspector
-		if field, ok := m.inspectorFieldAt(msg.Y, inspectorRect, compact); ok && msg.Action == tea.MouseActionPress {
+		if field, ok := m.inspectorFieldAt(msg.Y, inspectorRect, compact, wasFocused); ok && msg.Action == tea.MouseActionPress {
 			m.inspectorField = field
 			switch msg.Button {
 			case tea.MouseButtonLeft:
@@ -1357,24 +1358,30 @@ func (m Model) canvasLocalPoint(x, y int, canvasRect hitRect) (int, int) {
 	return x - canvasX, y - canvasY
 }
 
-func (m Model) inspectorFieldAt(y int, inspectorRect hitRect, compact bool) (int, bool) {
+func (m Model) inspectorFieldAt(y int, inspectorRect hitRect, compact bool, wasFocused bool) (int, bool) {
 	if len(m.editOutputs) == 0 {
 		return 0, false
 	}
 	inner := inspectorRect.inner(m.styles.inactivePane)
-	row := inner.y + 4
-	if !compact {
-		output := m.editOutputs[m.selectedOutput]
-		detailCount := len(m.inspectorDetailLines(output))
-		// header + blank + info + details + blank + preferences
-		row = inner.y + detailCount + 5
+	localY := y - inner.y
+	if localY < 0 || localY >= inner.h {
+		return 0, false
 	}
-	for idx := range layoutFields {
-		offset := idx
-		if idx >= advancedFieldStart {
-			offset++ // spacer row before advanced fields
+
+	layout := m.buildInspectorLayout(m.editOutputs[m.selectedOutput], inner.w, compact)
+	scrollOffset := 0
+	if wasFocused {
+		if row, ok := layout.fieldRows[m.inspectorField]; ok {
+			scrollOffset = inspectorScrollOffset(len(layout.lines), row, inner.h)
 		}
-		if y == row+offset {
+	}
+
+	for idx := range layoutFields {
+		row, ok := layout.fieldRows[idx]
+		if !ok {
+			continue
+		}
+		if row-scrollOffset == localY {
 			return idx, true
 		}
 	}

--- a/internal/tui/interaction.go
+++ b/internal/tui/interaction.go
@@ -270,13 +270,13 @@ func (m *Model) activateInspectorField() tea.Cmd {
 			"Type a scale like 1, 1.25, or 1.67. Enter applies. Esc cancels.",
 			strconv.FormatFloat(output.Scale, 'f', 2, 64),
 		)
-	case 5, 6:
+	case 7, 8:
 		output := m.editOutputs[m.selectedOutput]
 		kind := numericInputPositionX
 		title := fmt.Sprintf("Set Position X for %s", output.Name)
 		hint := "Type the exact X position in logical pixels. Enter applies. Esc cancels."
 		value := strconv.Itoa(output.X)
-		if m.inspectorField == 6 {
+		if m.inspectorField == 8 {
 			kind = numericInputPositionY
 			title = fmt.Sprintf("Set Position Y for %s", output.Name)
 			hint = "Type the exact Y position in logical pixels. Enter applies. Esc cancels."

--- a/internal/tui/interaction.go
+++ b/internal/tui/interaction.go
@@ -34,6 +34,7 @@ const (
 	numericInputScale numericInputKind = iota
 	numericInputPositionX
 	numericInputPositionY
+	numericInputICC
 )
 
 type numericInputState struct {
@@ -283,6 +284,15 @@ func (m *Model) activateInspectorField() tea.Cmd {
 			value = strconv.Itoa(output.Y)
 		}
 		return m.openNumericInput(kind, m.selectedOutput, title, hint, value)
+	case 20:
+		output := m.editOutputs[m.selectedOutput]
+		return m.openNumericInput(
+			numericInputICC,
+			m.selectedOutput,
+			fmt.Sprintf("Set ICC Profile for %s", output.Name),
+			"Absolute path to ICC profile. Leave empty to clear. Enter applies. Esc cancels.",
+			output.ICC,
+		)
 	default:
 		m.adjustInspectorField(1)
 		return nil
@@ -293,6 +303,9 @@ func (m *Model) openNumericInput(kind numericInputKind, outputIndex int, title s
 	input := textinput.New()
 	input.Prompt = ""
 	input.CharLimit = 8
+	if kind == numericInputICC {
+		input.CharLimit = 256
+	}
 	input.Width = clampInt(m.modalMaxWidth()-16, 8, 12)
 	input.TextStyle = m.styles.value
 	input.PlaceholderStyle = m.styles.subtle
@@ -681,6 +694,13 @@ func (m *Model) commitNumericInput() tea.Cmd {
 		}
 		output.Y = value
 		status = fmt.Sprintf("Position Y set to %d for %s", value, output.Name)
+	case numericInputICC:
+		output.ICC = strings.TrimSpace(m.input.Input.Value())
+		if output.ICC == "" {
+			status = fmt.Sprintf("ICC profile cleared for %s", output.Name)
+		} else {
+			status = fmt.Sprintf("ICC profile set for %s", output.Name)
+		}
 	}
 	m.layoutChanged()
 	m.setStatusOK(status)

--- a/internal/tui/interaction.go
+++ b/internal/tui/interaction.go
@@ -25,6 +25,7 @@ func (i pickerItem) Description() string { return "" }
 
 type modePickerState struct {
 	OutputIndex int
+	FieldIndex  int // -1 for mode picker, >= 0 for field option picker
 	List        list.Model
 }
 
@@ -35,11 +36,14 @@ const (
 	numericInputPositionX
 	numericInputPositionY
 	numericInputICC
+	numericInputFloat
+	numericInputInt
 )
 
 type numericInputState struct {
 	Kind        numericInputKind
 	OutputIndex int
+	FieldIndex  int
 	Title       string
 	Hint        string
 	Input       textinput.Model
@@ -258,6 +262,7 @@ func (m *Model) activateInspectorField() tea.Cmd {
 		picker.Select(clampIndex(output.ModeIndex, len(output.Modes)))
 		m.picker = &modePickerState{
 			OutputIndex: m.selectedOutput,
+			FieldIndex:  -1,
 			List:        picker,
 		}
 		m.mode = modeModePicker
@@ -284,6 +289,57 @@ func (m *Model) activateInspectorField() tea.Cmd {
 			value = strconv.Itoa(output.Y)
 		}
 		return m.openNumericInput(kind, m.selectedOutput, title, hint, value)
+	case 3:
+		m.openFieldPicker("Bit Depth", m.inspectorField, []string{"8", "10", "16"})
+		return nil
+	case 4:
+		m.openFieldPicker("Color Management", m.inspectorField, []string{"srgb", "auto", "wide", "hdr", "hdredid", "dcip3", "dp3", "adobe", "edid"})
+		return nil
+	case 5:
+		m.openFieldPicker("VRR", m.inspectorField, []string{"off", "on", "fullscreen"})
+		return nil
+	case 6:
+		m.openFieldPicker("Transform", m.inspectorField, []string{"normal", "90", "180", "270", "flipped", "flipped+90", "flipped+180", "flipped+270"})
+		return nil
+	case 9:
+		targets := []string{"None"}
+		for i, other := range m.editOutputs {
+			if i != m.selectedOutput {
+				targets = append(targets, other.displayModelLabel())
+			}
+		}
+		m.openFieldPicker("Mirror", m.inspectorField, targets)
+		return nil
+	case 10:
+		output := m.editOutputs[m.selectedOutput]
+		return m.openNumericInput(numericInputFloat, m.selectedOutput, "SDR Brightness", "Value between 0 and 3. Enter applies. Esc cancels.", fmt.Sprintf("%.2f", output.SDRBrightness))
+	case 11:
+		output := m.editOutputs[m.selectedOutput]
+		return m.openNumericInput(numericInputFloat, m.selectedOutput, "SDR Saturation", "Value between 0 and 3. Enter applies. Esc cancels.", fmt.Sprintf("%.2f", output.SDRSaturation))
+	case 12:
+		output := m.editOutputs[m.selectedOutput]
+		return m.openNumericInput(numericInputFloat, m.selectedOutput, "SDR Min Luminance", "Value between 0 and 1. Enter applies. Esc cancels.", fmt.Sprintf("%.3f", output.SDRMinLuminance))
+	case 13:
+		output := m.editOutputs[m.selectedOutput]
+		return m.openNumericInput(numericInputInt, m.selectedOutput, "SDR Max Luminance", "Integer between 0 and 1000. Enter applies. Esc cancels.", fmt.Sprintf("%d", output.SDRMaxLuminance))
+	case 14:
+		m.openFieldPicker("SDR Transfer Curve", m.inspectorField, []string{"default", "gamma22", "srgb"})
+		return nil
+	case 15:
+		output := m.editOutputs[m.selectedOutput]
+		return m.openNumericInput(numericInputFloat, m.selectedOutput, "Min Luminance", "Monitor minimum luminance. Enter applies. Esc cancels.", fmt.Sprintf("%.3f", output.MinLuminance))
+	case 16:
+		output := m.editOutputs[m.selectedOutput]
+		return m.openNumericInput(numericInputInt, m.selectedOutput, "Max Luminance", "Monitor maximum luminance. Enter applies. Esc cancels.", fmt.Sprintf("%d", output.MaxLuminance))
+	case 17:
+		output := m.editOutputs[m.selectedOutput]
+		return m.openNumericInput(numericInputInt, m.selectedOutput, "Max Avg Luminance", "Monitor average luminance. Enter applies. Esc cancels.", fmt.Sprintf("%d", output.MaxAvgLuminance))
+	case 18:
+		m.openFieldPicker("Force Wide Color", m.inspectorField, []string{"off", "auto", "on"})
+		return nil
+	case 19:
+		m.openFieldPicker("Force HDR", m.inspectorField, []string{"off", "auto", "on"})
+		return nil
 	case 20:
 		output := m.editOutputs[m.selectedOutput]
 		return m.openNumericInput(
@@ -299,14 +355,56 @@ func (m *Model) activateInspectorField() tea.Cmd {
 	}
 }
 
+func (m *Model) openFieldPicker(title string, fieldIndex int, options []string) {
+	output := m.editOutputs[m.selectedOutput]
+	currentValue := m.layoutFieldValue(output, fieldIndex)
+
+	items := make([]list.Item, 0, len(options))
+	selected := 0
+	for i, opt := range options {
+		items = append(items, pickerItem(opt))
+		if opt == currentValue {
+			selected = i
+		}
+	}
+	inner := list.NewDefaultDelegate()
+	inner.SetHeight(1)
+	inner.SetSpacing(0)
+	inner.Styles.NormalTitle = m.styles.value
+	inner.Styles.SelectedTitle = m.styles.focused.Copy().UnsetPadding()
+	inner.Styles.DimmedTitle = m.styles.subtle
+	inner.Styles.FilterMatch = m.styles.badgeAccent
+	delegate := arrowDelegate{inner}
+	height := clampInt(len(options)+2, 4, 12)
+	picker := list.New(items, delegate, m.modePickerWidth()-2, height)
+	picker.Title = title
+	picker.SetShowHelp(false)
+	picker.SetShowPagination(false)
+	picker.SetShowStatusBar(false)
+	picker.SetFilteringEnabled(false)
+	picker.DisableQuitKeybindings()
+	picker.Styles.Title = m.styles.modalTitle
+	picker.Styles.TitleBar = lipgloss.NewStyle().PaddingBottom(1)
+	picker.Styles.PaginationStyle = m.styles.subtle
+	picker.Styles.HelpStyle = m.styles.help
+	picker.Styles.NoItems = m.styles.subtle
+	picker.Select(selected)
+	m.picker = &modePickerState{
+		OutputIndex: m.selectedOutput,
+		FieldIndex:  fieldIndex,
+		List:        picker,
+	}
+	m.mode = modeModePicker
+}
+
 func (m *Model) openNumericInput(kind numericInputKind, outputIndex int, title string, hint string, value string) tea.Cmd {
 	input := textinput.New()
 	input.Prompt = ""
-	input.CharLimit = 8
+	input.CharLimit = 12
 	if kind == numericInputICC {
 		input.CharLimit = 256
 	}
-	input.Width = clampInt(m.modalMaxWidth()-16, 8, 12)
+	input.Width = clampInt(m.modalMaxWidth()-16, 12, 40)
 	input.TextStyle = m.styles.value
 	input.PlaceholderStyle = m.styles.subtle
 	input.Cursor.Style = lipgloss.NewStyle()
@@ -318,6 +416,7 @@ func (m *Model) openNumericInput(kind numericInputKind, outputIndex int, title s
 	m.input = &numericInputState{
 		Kind:        kind,
 		OutputIndex: outputIndex,
+		FieldIndex:  m.inspectorField,
 		Title:       title,
 		Hint:        hint,
 		Input:       input,
@@ -623,7 +722,18 @@ func (m *Model) commitModePicker() tea.Cmd {
 	}
 
 	output := &m.editOutputs[m.picker.OutputIndex]
-	output.ModeIndex = indexOf(output.Modes, string(selected))
+	value := string(selected)
+
+	if m.picker.FieldIndex >= 0 {
+		m.applyFieldPickerValue(output, m.picker.FieldIndex, value)
+		m.layoutChanged()
+		m.setStatusOK(fmt.Sprintf("Set %s to %s for %s", layoutFields[m.picker.FieldIndex], value, output.Name))
+		m.picker = nil
+		m.mode = modeMain
+		return nil
+	}
+
+	output.ModeIndex = indexOf(output.Modes, value)
 	if output.ModeIndex < 0 {
 		output.ModeIndex = 0
 	}
@@ -633,6 +743,81 @@ func (m *Model) commitModePicker() tea.Cmd {
 	m.picker = nil
 	m.mode = modeMain
 	return nil
+}
+
+func (m *Model) applyFieldPickerValue(output *editableOutput, field int, value string) {
+	switch field {
+	case 3:
+		output.Bitdepth, _ = strconv.Atoi(value)
+	case 4:
+		output.CM = value
+	case 5:
+		switch value {
+		case "on":
+			output.VRR = 1
+		case "fullscreen":
+			output.VRR = 2
+		default:
+			output.VRR = 0
+		}
+	case 6:
+		for i, label := range []string{"normal", "90", "180", "270", "flipped", "flipped+90", "flipped+180", "flipped+270"} {
+			if label == value {
+				output.Transform = i
+				break
+			}
+		}
+	case 9:
+		if value == "None" {
+			output.MirrorOf = ""
+		} else {
+			for _, other := range m.editOutputs {
+				if other.displayModelLabel() == value {
+					output.MirrorOf = other.Key
+					break
+				}
+			}
+		}
+	case 14:
+		output.SDREOTF = value
+	case 18:
+		switch value {
+		case "off":
+			output.SupportsWideColor = -1
+		case "on":
+			output.SupportsWideColor = 1
+		default:
+			output.SupportsWideColor = 0
+		}
+	case 19:
+		switch value {
+		case "off":
+			output.SupportsHDR = -1
+		case "on":
+			output.SupportsHDR = 1
+		default:
+			output.SupportsHDR = 0
+		}
+	}
+}
+
+func (m *Model) applyNumericFieldValue(output *editableOutput, field int, value float64) {
+	switch field {
+	case 10:
+		output.SDRBrightness = value
+	case 11:
+		output.SDRSaturation = value
+	case 12:
+		output.SDRMinLuminance = value
+	case 13:
+		output.SDRMaxLuminance = int(value)
+	case 15:
+		output.MinLuminance = value
+	case 16:
+		output.MaxLuminance = int(value)
+	case 17:
+		output.MaxAvgLuminance = int(value)
+	}
 }
 
 func (m *Model) updateNumericInputKeys(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
@@ -701,6 +886,22 @@ func (m *Model) commitNumericInput() tea.Cmd {
 		} else {
 			status = fmt.Sprintf("ICC profile set for %s", output.Name)
 		}
+	case numericInputFloat:
+		value, err := strconv.ParseFloat(strings.TrimSpace(m.input.Input.Value()), 64)
+		if err != nil {
+			m.input.Input.Err = fmt.Errorf("must be a number")
+			return nil
+		}
+		m.applyNumericFieldValue(output, m.input.FieldIndex, value)
+		status = fmt.Sprintf("%s set for %s", m.input.Title, output.Name)
+	case numericInputInt:
+		value, err := strconv.Atoi(strings.TrimSpace(m.input.Input.Value()))
+		if err != nil {
+			m.input.Input.Err = fmt.Errorf("must be an integer")
+			return nil
+		}
+		m.applyNumericFieldValue(output, m.input.FieldIndex, float64(value))
+		status = fmt.Sprintf("%s set for %s", m.input.Title, output.Name)
 	}
 	m.layoutChanged()
 	m.setStatusOK(status)
@@ -1162,7 +1363,11 @@ func (m Model) inspectorFieldAt(y int, inspectorRect hitRect, compact bool) (int
 		row = inner.y + detailCount + 5
 	}
 	for idx := range layoutFields {
-		if y == row+idx {
+		offset := idx
+		if idx >= advancedFieldStart {
+			offset++ // spacer row before advanced fields
+		}
+		if y == row+offset {
 			return idx, true
 		}
 	}

--- a/internal/tui/interaction.go
+++ b/internal/tui/interaction.go
@@ -397,6 +397,13 @@ func (m *Model) openFieldPicker(title string, fieldIndex int, options []string) 
 	m.mode = modeModePicker
 }
 
+func (m Model) numericInputWidthFor(kind numericInputKind) int {
+	if kind == numericInputICC {
+		return clampInt(m.modalMaxWidth()-16, 20, 60)
+	}
+	return clampInt(m.modalMaxWidth()-16, 8, 12)
+}
+
 func (m *Model) openNumericInput(kind numericInputKind, outputIndex int, title string, hint string, value string) tea.Cmd {
 	input := textinput.New()
 	input.Prompt = ""
@@ -404,7 +411,7 @@ func (m *Model) openNumericInput(kind numericInputKind, outputIndex int, title s
 	if kind == numericInputICC {
 		input.CharLimit = 256
 	}
-	input.Width = clampInt(m.modalMaxWidth()-16, 12, 40)
+	input.Width = m.numericInputWidthFor(kind)
 	input.TextStyle = m.styles.value
 	input.PlaceholderStyle = m.styles.subtle
 	input.Cursor.Style = lipgloss.NewStyle()

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -115,6 +115,14 @@ type editableOutput struct {
 	DPMSStatus      bool
 	MirrorOf        string
 	ActiveWorkspace string
+	Bitdepth        int
+	CM              string
+	SDRBrightness   float64
+	SDRSaturation   float64
+	SDRMinLuminance float64
+	SDRMaxLuminance int
+	MinLuminance    int
+	MaxLuminance    int
 }
 
 type canvasCell struct {
@@ -205,6 +213,7 @@ type Model struct {
 	snap          *snapHintState
 	snapSeq       int
 
+	showAdvanced     bool
 	status           string
 	statusErr        bool
 	dirty            bool
@@ -495,13 +504,18 @@ func (m *Model) updateLayoutKeys(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 
 	switch msg.String() {
 	case "up", "k":
-		m.inspectorField = clampIndex(m.inspectorField-1, len(layoutFields))
+		m.inspectorField = clampIndex(m.inspectorField-1, m.visibleFieldCount())
 	case "down", "j":
-		m.inspectorField = clampIndex(m.inspectorField+1, len(layoutFields))
+		m.inspectorField = clampIndex(m.inspectorField+1, m.visibleFieldCount())
 	case "left", "h", "-", "_":
 		m.adjustInspectorField(-1)
 	case "right", "l", "+", "=":
 		m.adjustInspectorField(1)
+	case "x":
+		m.showAdvanced = !m.showAdvanced
+		if !m.showAdvanced && m.inspectorField >= baseFieldCount {
+			m.inspectorField = baseFieldCount - 1
+		}
 	case " ", "enter":
 		return m, m.activateInspectorField()
 	default:
@@ -1094,6 +1108,13 @@ func (m Model) compactLayoutHeights(total int) (int, int) {
 	return max(2, canvas), max(1, inspector)
 }
 
+func (m Model) visibleFieldCount() int {
+	if m.showAdvanced {
+		return len(layoutFields)
+	}
+	return baseFieldCount
+}
+
 func (m Model) inspectorFieldLines(output editableOutput, innerWidth int, compact bool) []string {
 	if compact {
 		return m.compactInspectorFieldLines(output, innerWidth)
@@ -1105,8 +1126,14 @@ func (m Model) inspectorFieldLines(output editableOutput, innerWidth int, compac
 		labelWidth = 8
 	}
 
-	lines := make([]string, 0, len(layoutFields))
-	for idx := range layoutFields {
+	fieldCount := m.visibleFieldCount()
+	lines := make([]string, 0, fieldCount+1)
+	for idx := 0; idx < fieldCount; idx++ {
+		if idx == baseFieldCount {
+			lines = append(lines, "")
+			lines = append(lines, m.styles.header.Render("▼ Advanced")+" "+m.styles.subtle.Render("(x)"))
+		}
+
 		labelText := layoutFields[idx]
 		if shortLabels {
 			labelText = layoutFieldShortLabel(idx)
@@ -1120,6 +1147,11 @@ func (m Model) inspectorFieldLines(output editableOutput, innerWidth int, compac
 		lines = append(lines, fmt.Sprintf("%s %s", label, value))
 	}
 
+	if !m.showAdvanced {
+		toggle := m.styles.subtle.Render("▶ Advanced (x)")
+		lines = append(lines, "", toggle)
+	}
+
 	return lines
 }
 
@@ -1131,14 +1163,14 @@ func (m Model) compactInspectorFieldLines(output editableOutput, innerWidth int)
 			joinInspectorTokens(
 				m.inspectorCompactFieldToken("On", 0, output),
 				m.inspectorCompactFieldToken("Scale", 2, output),
-				m.inspectorCompactFieldToken("VRR", 3, output),
+				m.inspectorCompactFieldToken("VRR", 5, output),
 			),
 			joinInspectorTokens(
-				m.inspectorCompactFieldToken("Rot", 4, output),
-				m.inspectorCompactFieldToken("X", 5, output),
-				m.inspectorCompactFieldToken("Y", 6, output),
+				m.inspectorCompactFieldToken("Rot", 6, output),
+				m.inspectorCompactFieldToken("X", 7, output),
+				m.inspectorCompactFieldToken("Y", 8, output),
 			),
-			m.inspectorCompactFieldLine("Mirror", 7, output),
+			m.inspectorCompactFieldLine("Mirror", 9, output),
 		}
 	case innerWidth >= 36:
 		return []string{
@@ -1148,14 +1180,14 @@ func (m Model) compactInspectorFieldLines(output editableOutput, innerWidth int)
 				m.inspectorCompactFieldToken("Scale", 2, output),
 			),
 			joinInspectorTokens(
-				m.inspectorCompactFieldToken("VRR", 3, output),
-				m.inspectorCompactFieldToken("Rot", 4, output),
+				m.inspectorCompactFieldToken("VRR", 5, output),
+				m.inspectorCompactFieldToken("Rot", 6, output),
 			),
 			joinInspectorTokens(
-				m.inspectorCompactFieldToken("X", 5, output),
-				m.inspectorCompactFieldToken("Y", 6, output),
+				m.inspectorCompactFieldToken("X", 7, output),
+				m.inspectorCompactFieldToken("Y", 8, output),
 			),
-			m.inspectorCompactFieldLine("Mirror", 7, output),
+			m.inspectorCompactFieldLine("Mirror", 9, output),
 		}
 	default:
 		return []string{
@@ -1163,14 +1195,14 @@ func (m Model) compactInspectorFieldLines(output editableOutput, innerWidth int)
 			m.inspectorCompactFieldLine("On", 0, output),
 			m.inspectorCompactFieldLine("Scale", 2, output),
 			joinInspectorTokens(
-				m.inspectorCompactFieldToken("VRR", 3, output),
-				m.inspectorCompactFieldToken("Rot", 4, output),
+				m.inspectorCompactFieldToken("VRR", 5, output),
+				m.inspectorCompactFieldToken("Rot", 6, output),
 			),
 			joinInspectorTokens(
-				m.inspectorCompactFieldToken("X", 5, output),
-				m.inspectorCompactFieldToken("Y", 6, output),
+				m.inspectorCompactFieldToken("X", 7, output),
+				m.inspectorCompactFieldToken("Y", 8, output),
 			),
-			m.inspectorCompactFieldLine("Mirror", 7, output),
+			m.inspectorCompactFieldLine("Mirror", 9, output),
 		}
 	}
 }
@@ -1255,13 +1287,37 @@ func (m *Model) loadLiveState() {
 	} else {
 		m.draftProfileName = ""
 	}
+
+	// Preserve fields that hyprctl cannot report: VRR mode (only a bool),
+	// and config-only EDID overrides (min/max luminance).
+	for i := range m.editOutputs {
+		for _, prev := range prevOutputs {
+			if prev.Key == m.editOutputs[i].Key {
+				m.editOutputs[i].VRR = prev.VRR
+				m.editOutputs[i].MinLuminance = prev.MinLuminance
+				m.editOutputs[i].MaxLuminance = prev.MaxLuminance
+				break
+			}
+		}
+	}
+	if len(prevOutputs) == 0 {
+		if best, _, ok := profile.BestMatch(m.profiles, m.monitors); ok {
+			for i := range m.editOutputs {
+				if saved, ok := best.OutputByKey(m.editOutputs[i].Key); ok {
+					m.editOutputs[i].VRR = saved.VRR
+					m.editOutputs[i].MinLuminance = saved.MinLuminance
+					m.editOutputs[i].MaxLuminance = saved.MaxLuminance
+				}
+			}
+		}
+	}
 	if idx := focusedOutputIndex(m.editOutputs); idx >= 0 {
 		m.selectedOutput = idx
 	} else if selectedKey != "" {
 		m.selectedOutput = outputIndexByKey(m.editOutputs, selectedKey)
 	}
 	m.selectedOutput = clampIndex(m.selectedOutput, len(m.editOutputs))
-	m.inspectorField = clampIndex(m.inspectorField, len(layoutFields))
+	m.inspectorField = clampIndex(m.inspectorField, m.visibleFieldCount())
 	m.picker = nil
 	m.input = nil
 	m.drag = nil
@@ -1319,7 +1375,7 @@ func (m *Model) recoverMirroredIdentity() {
 func (m *Model) syncSelections() {
 	m.selectedOutput = clampIndex(m.selectedOutput, len(m.editOutputs))
 	m.selectedProfile = clampIndex(m.selectedProfile, len(m.profiles))
-	m.inspectorField = clampIndex(m.inspectorField, len(layoutFields))
+	m.inspectorField = clampIndex(m.inspectorField, m.visibleFieldCount())
 	m.workspaceEdit.SelectedField = clampIndex(m.workspaceEdit.SelectedField, len(workspaceFields))
 	m.workspaceEdit.SelectedOrder = clampIndex(m.workspaceEdit.SelectedOrder, len(m.workspaceEdit.MonitorOrder))
 }
@@ -1526,14 +1582,34 @@ func (m *Model) adjustInspectorField(delta int) {
 	case 2:
 		output.Scale = clampFloat(output.Scale+float64(delta)*0.05, 0.25, 4.0)
 	case 3:
-		output.VRR = wrapValue(output.VRR+delta, 0, 2)
+		depths := []int{8, 10, 16}
+		current := 0
+		for i, d := range depths {
+			if d == output.Bitdepth {
+				current = i
+				break
+			}
+		}
+		output.Bitdepth = depths[wrapIndex(current+delta, len(depths))]
 	case 4:
-		output.Transform = wrapValue(output.Transform+delta, 0, 7)
+		presets := []string{"srgb", "wide", "hdr", "hdredid"}
+		current := 0
+		for i, p := range presets {
+			if p == output.CM {
+				current = i
+				break
+			}
+		}
+		output.CM = presets[wrapIndex(current+delta, len(presets))]
 	case 5:
-		output.X += delta * 10
+		output.VRR = wrapValue(output.VRR+delta, 0, 2)
 	case 6:
-		output.Y += delta * 10
+		output.Transform = wrapValue(output.Transform+delta, 0, 7)
 	case 7:
+		output.X += delta * 10
+	case 8:
+		output.Y += delta * 10
+	case 9:
 		targets := []string{""}
 		for i, other := range m.editOutputs {
 			if i != m.selectedOutput {
@@ -1548,6 +1624,18 @@ func (m *Model) adjustInspectorField(delta int) {
 			}
 		}
 		output.MirrorOf = targets[wrapIndex(current+delta, len(targets))]
+	case 10:
+		output.SDRBrightness = clampFloat(output.SDRBrightness+float64(delta)*0.05, 0, 3.0)
+	case 11:
+		output.SDRSaturation = clampFloat(output.SDRSaturation+float64(delta)*0.05, 0, 3.0)
+	case 12:
+		output.SDRMinLuminance = clampFloat(output.SDRMinLuminance+float64(delta)*0.005, 0, 1.0)
+	case 13:
+		output.SDRMaxLuminance = clampInt(output.SDRMaxLuminance+delta*10, 0, 1000)
+	case 14:
+		output.MinLuminance = clampInt(output.MinLuminance+delta*1, 0, 1000)
+	case 15:
+		output.MaxLuminance = clampInt(output.MaxLuminance+delta*10, 0, 2000)
 	}
 	m.layoutChanged()
 }
@@ -1722,14 +1810,21 @@ func (m Model) layoutFieldValue(output editableOutput, field int) string {
 	case 2:
 		return fmt.Sprintf("%.2f", output.Scale)
 	case 3:
-		return vrrLabel(output.VRR)
+		return fmt.Sprintf("%d", output.Bitdepth)
 	case 4:
-		return transformLabel(output.Transform)
+		if output.CM == "" {
+			return "srgb"
+		}
+		return output.CM
 	case 5:
-		return fmt.Sprintf("%d", output.X)
+		return vrrLabel(output.VRR)
 	case 6:
-		return fmt.Sprintf("%d", output.Y)
+		return transformLabel(output.Transform)
 	case 7:
+		return fmt.Sprintf("%d", output.X)
+	case 8:
+		return fmt.Sprintf("%d", output.Y)
+	case 9:
 		if output.MirrorOf == "" {
 			return "None"
 		}
@@ -1739,6 +1834,18 @@ func (m Model) layoutFieldValue(output editableOutput, field int) string {
 			}
 		}
 		return output.MirrorOf
+	case 10:
+		return fmt.Sprintf("%.2f", output.SDRBrightness)
+	case 11:
+		return fmt.Sprintf("%.2f", output.SDRSaturation)
+	case 12:
+		return fmt.Sprintf("%.3f", output.SDRMinLuminance)
+	case 13:
+		return fmt.Sprintf("%d", output.SDRMaxLuminance)
+	case 14:
+		return fmt.Sprintf("%d", output.MinLuminance)
+	case 15:
+		return fmt.Sprintf("%d", output.MaxLuminance)
 	default:
 		return ""
 	}
@@ -1861,12 +1968,18 @@ func editableOutputFromMonitor(m hypr.Monitor, matchCounts map[string]int) edita
 		X:               m.X,
 		Y:               m.Y,
 		Scale:           clampFloat(m.Scale, 0.25, 4.0),
-		VRR:             boolToVRR(m.VRR),
+		VRR:             int(m.VRR),
 		Transform:       m.Transform,
 		Focused:         m.Focused,
 		DPMSStatus:      m.DPMSStatus,
 		MirrorOf:        m.MirrorOf,
 		ActiveWorkspace: m.ActiveWorkspace.Name,
+		Bitdepth:        m.Bitdepth(),
+		CM:              m.ColorManagementPreset,
+		SDRBrightness:   m.SDRBrightness,
+		SDRSaturation:   m.SDRSaturation,
+		SDRMinLuminance: m.SDRMinLuminance,
+		SDRMaxLuminance: m.SDRMaxLuminance,
 	}
 
 	output.Modes = normalizeModes(m.AvailableModes, m.ModeString())
@@ -1882,22 +1995,30 @@ func editableOutputFromMonitor(m hypr.Monitor, matchCounts map[string]int) edita
 
 func editableOutputFromProfile(saved profile.OutputConfig, live hypr.Monitor, hasLive bool) editableOutput {
 	output := editableOutput{
-		Key:       saved.Key,
-		MatchKey:  saved.MatchIdentity(),
-		Name:      saved.Name,
-		Make:      saved.Make,
-		Model:     saved.Model,
-		Serial:    saved.Serial,
-		Enabled:   saved.Enabled,
-		Width:     saved.Width,
-		Height:    saved.Height,
-		Refresh:   saved.Refresh,
-		X:         saved.X,
-		Y:         saved.Y,
-		Scale:     clampFloat(saved.Scale, 0.25, 4.0),
-		VRR:       saved.VRR,
-		Transform: saved.Transform,
-		MirrorOf:  saved.MirrorOf,
+		Key:             saved.Key,
+		MatchKey:        saved.MatchIdentity(),
+		Name:            saved.Name,
+		Make:            saved.Make,
+		Model:           saved.Model,
+		Serial:          saved.Serial,
+		Enabled:         saved.Enabled,
+		Width:           saved.Width,
+		Height:          saved.Height,
+		Refresh:         saved.Refresh,
+		X:               saved.X,
+		Y:               saved.Y,
+		Scale:           clampFloat(saved.Scale, 0.25, 4.0),
+		VRR:             saved.VRR,
+		Transform:       saved.Transform,
+		MirrorOf:        saved.MirrorOf,
+		Bitdepth:        saved.Bitdepth,
+		CM:              saved.CM,
+		SDRBrightness:   saved.SDRBrightness,
+		SDRSaturation:   saved.SDRSaturation,
+		SDRMinLuminance: saved.SDRMinLuminance,
+		SDRMaxLuminance: saved.SDRMaxLuminance,
+		MinLuminance:    saved.MinLuminance,
+		MaxLuminance:    saved.MaxLuminance,
 	}
 
 	mode := saved.NormalizedMode()
@@ -2053,23 +2174,31 @@ func (o editableOutput) DisplayMode() string {
 
 func (o editableOutput) profileOutput() profile.OutputConfig {
 	return profile.OutputConfig{
-		Key:       o.Key,
-		MatchKey:  o.MatchKey,
-		Name:      o.Name,
-		Make:      o.Make,
-		Model:     o.Model,
-		Serial:    o.Serial,
-		Enabled:   o.Enabled,
-		Mode:      o.DisplayMode(),
-		Width:     o.Width,
-		Height:    o.Height,
-		Refresh:   o.Refresh,
-		X:         o.X,
-		Y:         o.Y,
-		Scale:     o.Scale,
-		VRR:       o.VRR,
-		Transform: o.Transform,
-		MirrorOf:  o.MirrorOf,
+		Key:             o.Key,
+		MatchKey:        o.MatchKey,
+		Name:            o.Name,
+		Make:            o.Make,
+		Model:           o.Model,
+		Serial:          o.Serial,
+		Enabled:         o.Enabled,
+		Mode:            o.DisplayMode(),
+		Width:           o.Width,
+		Height:          o.Height,
+		Refresh:         o.Refresh,
+		X:               o.X,
+		Y:               o.Y,
+		Scale:           o.Scale,
+		VRR:             o.VRR,
+		Transform:       o.Transform,
+		MirrorOf:        o.MirrorOf,
+		Bitdepth:        o.Bitdepth,
+		CM:              o.CM,
+		SDRBrightness:   o.SDRBrightness,
+		SDRSaturation:   o.SDRSaturation,
+		SDRMinLuminance: o.SDRMinLuminance,
+		SDRMaxLuminance: o.SDRMaxLuminance,
+		MinLuminance:    o.MinLuminance,
+		MaxLuminance:    o.MaxLuminance,
 	}
 }
 
@@ -2636,24 +2765,35 @@ var layoutFields = []string{
 	"Enabled",
 	"Mode",
 	"Scale",
+	"Bit Depth",
+	"Color Mgmt",
 	"VRR",
 	"Transform",
 	"Position X",
 	"Position Y",
 	"Mirror",
+	// Advanced fields (index baseFieldCount+)
+	"SDR Bright",
+	"SDR Satur",
+	"SDR Min Lum",
+	"SDR Max Lum",
+	"Min Lumin",
+	"Max Lumin",
 }
+
+const baseFieldCount = 10
 
 func layoutFieldShortLabel(field int) string {
 	switch field {
 	case 0:
 		return "On"
-	case 4:
-		return "Rot"
-	case 5:
-		return "X"
 	case 6:
-		return "Y"
+		return "Rot"
 	case 7:
+		return "X"
+	case 8:
+		return "Y"
+	case 9:
 		return "Mirror"
 	default:
 		return layoutFields[field]
@@ -2665,13 +2805,6 @@ var workspaceFields = []string{
 	"Strategy",
 	"Max workspaces",
 	"Group size",
-}
-
-func boolToVRR(v bool) int {
-	if v {
-		return 1
-	}
-	return 0
 }
 
 func (m Model) isOutputOverlapping(o editableOutput) bool {

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -275,7 +275,7 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			m.saveDialog.Input.Width = m.saveDialogInputWidth()
 		}
 		if m.input != nil {
-			m.input.Input.Width = clampInt(m.modalMaxWidth()-16, 8, 12)
+			m.input.Input.Width = m.numericInputWidthFor(m.input.Kind)
 		}
 		return m, nil
 
@@ -820,6 +820,7 @@ func (m Model) renderInspectorPane(width int, height int, compact bool) string {
 
 	output := m.editOutputs[m.selectedOutput]
 
+	detailCount := 0
 	if compact {
 		// Compact info: one-line summary
 		info := fmt.Sprintf("%s  %s  %s", output.Name, output.displayModelLabel(), output.DisplayMode())
@@ -829,6 +830,7 @@ func (m Model) renderInspectorPane(width int, height int, compact bool) string {
 		// Info section
 		lines = append(lines, m.styles.header.Render("Info"))
 		detailLines := m.inspectorDetailLines(output)
+		detailCount = len(detailLines)
 		lines = append(lines, detailLines...)
 	}
 
@@ -838,7 +840,30 @@ func (m Model) renderInspectorPane(width int, height int, compact bool) string {
 	fieldLines := m.inspectorFieldLines(output, innerWidth, false)
 	lines = append(lines, fieldLines...)
 
+	if !compact && m.layoutFocus == layoutFocusInspector && m.tab == tabLayout {
+		// header(1) + blank(1) + Info(1) + details(N) + blank(1) + Preferences(1) = N+5
+		fieldBase := 5 + detailCount
+		selectedLine := fieldBase + m.inspectorField
+		if m.inspectorField >= advancedFieldStart {
+			selectedLine++ // spacer row before advanced
+		}
+		lines = scrollLinesToFit(lines, selectedLine, innerHeight)
+	}
+
 	return panel.Width(innerWidth).Render(fitBlock(strings.Join(lines, "\n"), innerWidth, innerHeight))
+}
+
+// scrollLinesToFit trims leading lines so that the line at selectedLine is
+// within the first `height` rows. Returns lines unchanged if already visible.
+func scrollLinesToFit(lines []string, selectedLine, height int) []string {
+	if height <= 0 || selectedLine < height {
+		return lines
+	}
+	offset := selectedLine - height + 1
+	if offset >= len(lines) {
+		offset = len(lines) - 1
+	}
+	return lines[offset:]
 }
 
 func (m Model) renderProfilesView(height int) string {

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -1288,12 +1288,15 @@ func (m *Model) loadLiveState() {
 		m.draftProfileName = ""
 	}
 
-	// Preserve fields that hyprctl cannot report: VRR mode (only a bool),
-	// and config-only EDID overrides (min/max luminance).
+	// Preserve fields from the previous TUI state that hyprctl cannot
+	// accurately report or that Hyprland may change as a side-effect
+	// (e.g. switching CM to "hdr" changes currentFormat/bitdepth).
 	for i := range m.editOutputs {
 		for _, prev := range prevOutputs {
 			if prev.Key == m.editOutputs[i].Key {
 				m.editOutputs[i].VRR = prev.VRR
+				m.editOutputs[i].Bitdepth = prev.Bitdepth
+				m.editOutputs[i].CM = prev.CM
 				m.editOutputs[i].MinLuminance = prev.MinLuminance
 				m.editOutputs[i].MaxLuminance = prev.MaxLuminance
 				break
@@ -1305,6 +1308,8 @@ func (m *Model) loadLiveState() {
 			for i := range m.editOutputs {
 				if saved, ok := best.OutputByKey(m.editOutputs[i].Key); ok {
 					m.editOutputs[i].VRR = saved.VRR
+					m.editOutputs[i].Bitdepth = saved.Bitdepth
+					m.editOutputs[i].CM = saved.CM
 					m.editOutputs[i].MinLuminance = saved.MinLuminance
 					m.editOutputs[i].MaxLuminance = saved.MaxLuminance
 				}

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -218,6 +218,7 @@ type Model struct {
 	snap          *snapHintState
 	snapSeq       int
 
+	resetRequested   bool
 	status           string
 	statusErr        bool
 	dirty            bool
@@ -440,6 +441,7 @@ func (m Model) updateMainKeys(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		m.tab = tabWorkspaces
 		return m, nil
 	case "r":
+		m.resetRequested = true
 		m.draftProfileName = ""
 		m.markClean()
 		return m, m.refreshCmd()
@@ -1118,8 +1120,11 @@ func (m Model) inspectorFieldLines(output editableOutput, innerWidth int, compac
 		labelWidth = 8
 	}
 
-	lines := make([]string, 0, len(layoutFields))
+	lines := make([]string, 0, len(layoutFields)+1)
 	for idx := range layoutFields {
+		if idx == advancedFieldStart {
+			lines = append(lines, "")
+		}
 		labelText := layoutFields[idx]
 		if shortLabels {
 			labelText = layoutFieldShortLabel(idx)
@@ -1269,27 +1274,28 @@ func (m *Model) loadLiveState() {
 		m.draftProfileName = ""
 	}
 
-	// Preserve fields from the previous TUI state that hyprctl cannot
-	// accurately report or that Hyprland may change as a side-effect
-	// (e.g. switching CM to "hdr" changes currentFormat/bitdepth).
-	for i := range m.editOutputs {
-		for _, prev := range prevOutputs {
-			if prev.Key == m.editOutputs[i].Key {
-				m.editOutputs[i].VRR = prev.VRR
-				m.editOutputs[i].Bitdepth = prev.Bitdepth
-				m.editOutputs[i].CM = prev.CM
-				m.editOutputs[i].MinLuminance = prev.MinLuminance
-				m.editOutputs[i].MaxLuminance = prev.MaxLuminance
-				m.editOutputs[i].SupportsWideColor = prev.SupportsWideColor
-				m.editOutputs[i].SupportsHDR = prev.SupportsHDR
-				m.editOutputs[i].MaxAvgLuminance = prev.MaxAvgLuminance
-				m.editOutputs[i].SDREOTF = prev.SDREOTF
-				m.editOutputs[i].ICC = prev.ICC
-				break
+	// Preserve fields that hyprctl cannot accurately report, unless the
+	// user explicitly requested a reset.
+	if !m.resetRequested {
+		for i := range m.editOutputs {
+			for _, prev := range prevOutputs {
+				if prev.Key == m.editOutputs[i].Key {
+					m.editOutputs[i].VRR = prev.VRR
+					m.editOutputs[i].Bitdepth = prev.Bitdepth
+					m.editOutputs[i].CM = prev.CM
+					m.editOutputs[i].MinLuminance = prev.MinLuminance
+					m.editOutputs[i].MaxLuminance = prev.MaxLuminance
+					m.editOutputs[i].SupportsWideColor = prev.SupportsWideColor
+					m.editOutputs[i].SupportsHDR = prev.SupportsHDR
+					m.editOutputs[i].MaxAvgLuminance = prev.MaxAvgLuminance
+					m.editOutputs[i].SDREOTF = prev.SDREOTF
+					m.editOutputs[i].ICC = prev.ICC
+					break
+				}
 			}
 		}
 	}
-	if len(prevOutputs) == 0 {
+	if len(prevOutputs) == 0 || m.resetRequested {
 		if best, _, ok := profile.BestMatch(m.profiles, m.monitors); ok {
 			for i := range m.editOutputs {
 				if saved, ok := best.OutputByKey(m.editOutputs[i].Key); ok {
@@ -1307,6 +1313,7 @@ func (m *Model) loadLiveState() {
 			}
 		}
 	}
+	m.resetRequested = false
 	if idx := focusedOutputIndex(m.editOutputs); idx >= 0 {
 		m.selectedOutput = idx
 	} else if selectedKey != "" {
@@ -2851,6 +2858,8 @@ var layoutFields = []string{
 	"Force HDR",
 	"ICC Path",
 }
+
+const advancedFieldStart = 10
 
 func layoutFieldShortLabel(field int) string {
 	switch field {

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -91,38 +91,43 @@ type pendingApply struct {
 }
 
 type editableOutput struct {
-	Key             string
-	MatchKey        string
-	Name            string
-	Description     string
-	Make            string
-	Model           string
-	Serial          string
-	PhysicalWidth   int
-	PhysicalHeight  int
-	Enabled         bool
-	Modes           []string
-	ModeIndex       int
-	Width           int
-	Height          int
-	Refresh         float64
-	X               int
-	Y               int
-	Scale           float64
-	VRR             int
-	Transform       int
-	Focused         bool
-	DPMSStatus      bool
-	MirrorOf        string
-	ActiveWorkspace string
-	Bitdepth        int
-	CM              string
-	SDRBrightness   float64
-	SDRSaturation   float64
-	SDRMinLuminance float64
-	SDRMaxLuminance int
-	MinLuminance    int
-	MaxLuminance    int
+	Key               string
+	MatchKey          string
+	Name              string
+	Description       string
+	Make              string
+	Model             string
+	Serial            string
+	PhysicalWidth     int
+	PhysicalHeight    int
+	Enabled           bool
+	Modes             []string
+	ModeIndex         int
+	Width             int
+	Height            int
+	Refresh           float64
+	X                 int
+	Y                 int
+	Scale             float64
+	VRR               int
+	Transform         int
+	Focused           bool
+	DPMSStatus        bool
+	MirrorOf          string
+	ActiveWorkspace   string
+	Bitdepth          int
+	CM                string
+	SDRBrightness     float64
+	SDRSaturation     float64
+	SDRMinLuminance   float64
+	SDRMaxLuminance   int
+	MinLuminance      float64
+	MaxLuminance      int
+	SupportsWideColor int
+	SupportsHDR       int
+	MaxAvgLuminance   int
+	SDREOTF           string
+	ICC               string
 }
 
 type canvasCell struct {
@@ -1299,6 +1304,11 @@ func (m *Model) loadLiveState() {
 				m.editOutputs[i].CM = prev.CM
 				m.editOutputs[i].MinLuminance = prev.MinLuminance
 				m.editOutputs[i].MaxLuminance = prev.MaxLuminance
+				m.editOutputs[i].SupportsWideColor = prev.SupportsWideColor
+				m.editOutputs[i].SupportsHDR = prev.SupportsHDR
+				m.editOutputs[i].MaxAvgLuminance = prev.MaxAvgLuminance
+				m.editOutputs[i].SDREOTF = prev.SDREOTF
+				m.editOutputs[i].ICC = prev.ICC
 				break
 			}
 		}
@@ -1312,6 +1322,11 @@ func (m *Model) loadLiveState() {
 					m.editOutputs[i].CM = saved.CM
 					m.editOutputs[i].MinLuminance = saved.MinLuminance
 					m.editOutputs[i].MaxLuminance = saved.MaxLuminance
+					m.editOutputs[i].SupportsWideColor = saved.SupportsWideColor
+					m.editOutputs[i].SupportsHDR = saved.SupportsHDR
+					m.editOutputs[i].MaxAvgLuminance = saved.MaxAvgLuminance
+					m.editOutputs[i].SDREOTF = saved.SDREOTF
+					m.editOutputs[i].ICC = saved.ICC
 				}
 			}
 		}
@@ -1597,7 +1612,7 @@ func (m *Model) adjustInspectorField(delta int) {
 		}
 		output.Bitdepth = depths[wrapIndex(current+delta, len(depths))]
 	case 4:
-		presets := []string{"srgb", "wide", "hdr", "hdredid"}
+		presets := []string{"srgb", "auto", "wide", "hdr", "hdredid", "dcip3", "dp3", "adobe", "edid"}
 		current := 0
 		for i, p := range presets {
 			if p == output.CM {
@@ -1638,9 +1653,43 @@ func (m *Model) adjustInspectorField(delta int) {
 	case 13:
 		output.SDRMaxLuminance = clampInt(output.SDRMaxLuminance+delta*10, 0, 1000)
 	case 14:
-		output.MinLuminance = clampInt(output.MinLuminance+delta*1, 0, 1000)
+		eotfs := []string{"default", "gamma22", "srgb"}
+		cur := 0
+		for i, e := range eotfs {
+			if e == output.SDREOTF {
+				cur = i
+				break
+			}
+		}
+		output.SDREOTF = eotfs[wrapIndex(cur+delta, len(eotfs))]
 	case 15:
+		output.MinLuminance = clampFloat(output.MinLuminance+float64(delta)*0.001, 0, 1000.0)
+	case 16:
 		output.MaxLuminance = clampInt(output.MaxLuminance+delta*10, 0, 2000)
+	case 17:
+		output.MaxAvgLuminance = clampInt(output.MaxAvgLuminance+delta*10, 0, 2000)
+	case 18:
+		vals := []int{-1, 0, 1}
+		cur := 1
+		for i, v := range vals {
+			if v == output.SupportsWideColor {
+				cur = i
+				break
+			}
+		}
+		output.SupportsWideColor = vals[wrapIndex(cur+delta, len(vals))]
+	case 19:
+		vals := []int{-1, 0, 1}
+		cur := 1
+		for i, v := range vals {
+			if v == output.SupportsHDR {
+				cur = i
+				break
+			}
+		}
+		output.SupportsHDR = vals[wrapIndex(cur+delta, len(vals))]
+	case 20:
+		// ICC uses text input via activateInspectorField
 	}
 	m.layoutChanged()
 }
@@ -1848,9 +1897,25 @@ func (m Model) layoutFieldValue(output editableOutput, field int) string {
 	case 13:
 		return fmt.Sprintf("%d", output.SDRMaxLuminance)
 	case 14:
-		return fmt.Sprintf("%d", output.MinLuminance)
+		if output.SDREOTF == "" {
+			return "default"
+		}
+		return output.SDREOTF
 	case 15:
+		return fmt.Sprintf("%.3f", output.MinLuminance)
+	case 16:
 		return fmt.Sprintf("%d", output.MaxLuminance)
+	case 17:
+		return fmt.Sprintf("%d", output.MaxAvgLuminance)
+	case 18:
+		return triStateLabel(output.SupportsWideColor)
+	case 19:
+		return triStateLabel(output.SupportsHDR)
+	case 20:
+		if output.ICC == "" {
+			return "None"
+		}
+		return output.ICC
 	default:
 		return ""
 	}
@@ -2000,30 +2065,35 @@ func editableOutputFromMonitor(m hypr.Monitor, matchCounts map[string]int) edita
 
 func editableOutputFromProfile(saved profile.OutputConfig, live hypr.Monitor, hasLive bool) editableOutput {
 	output := editableOutput{
-		Key:             saved.Key,
-		MatchKey:        saved.MatchIdentity(),
-		Name:            saved.Name,
-		Make:            saved.Make,
-		Model:           saved.Model,
-		Serial:          saved.Serial,
-		Enabled:         saved.Enabled,
-		Width:           saved.Width,
-		Height:          saved.Height,
-		Refresh:         saved.Refresh,
-		X:               saved.X,
-		Y:               saved.Y,
-		Scale:           clampFloat(saved.Scale, 0.25, 4.0),
-		VRR:             saved.VRR,
-		Transform:       saved.Transform,
-		MirrorOf:        saved.MirrorOf,
-		Bitdepth:        saved.Bitdepth,
-		CM:              saved.CM,
-		SDRBrightness:   saved.SDRBrightness,
-		SDRSaturation:   saved.SDRSaturation,
-		SDRMinLuminance: saved.SDRMinLuminance,
-		SDRMaxLuminance: saved.SDRMaxLuminance,
-		MinLuminance:    saved.MinLuminance,
-		MaxLuminance:    saved.MaxLuminance,
+		Key:               saved.Key,
+		MatchKey:          saved.MatchIdentity(),
+		Name:              saved.Name,
+		Make:              saved.Make,
+		Model:             saved.Model,
+		Serial:            saved.Serial,
+		Enabled:           saved.Enabled,
+		Width:             saved.Width,
+		Height:            saved.Height,
+		Refresh:           saved.Refresh,
+		X:                 saved.X,
+		Y:                 saved.Y,
+		Scale:             clampFloat(saved.Scale, 0.25, 4.0),
+		VRR:               saved.VRR,
+		Transform:         saved.Transform,
+		MirrorOf:          saved.MirrorOf,
+		Bitdepth:          saved.Bitdepth,
+		CM:                saved.CM,
+		SDRBrightness:     saved.SDRBrightness,
+		SDRSaturation:     saved.SDRSaturation,
+		SDRMinLuminance:   saved.SDRMinLuminance,
+		SDRMaxLuminance:   saved.SDRMaxLuminance,
+		MinLuminance:      saved.MinLuminance,
+		MaxLuminance:      saved.MaxLuminance,
+		SupportsWideColor: saved.SupportsWideColor,
+		SupportsHDR:       saved.SupportsHDR,
+		MaxAvgLuminance:   saved.MaxAvgLuminance,
+		SDREOTF:           saved.SDREOTF,
+		ICC:               saved.ICC,
 	}
 
 	mode := saved.NormalizedMode()
@@ -2179,31 +2249,36 @@ func (o editableOutput) DisplayMode() string {
 
 func (o editableOutput) profileOutput() profile.OutputConfig {
 	return profile.OutputConfig{
-		Key:             o.Key,
-		MatchKey:        o.MatchKey,
-		Name:            o.Name,
-		Make:            o.Make,
-		Model:           o.Model,
-		Serial:          o.Serial,
-		Enabled:         o.Enabled,
-		Mode:            o.DisplayMode(),
-		Width:           o.Width,
-		Height:          o.Height,
-		Refresh:         o.Refresh,
-		X:               o.X,
-		Y:               o.Y,
-		Scale:           o.Scale,
-		VRR:             o.VRR,
-		Transform:       o.Transform,
-		MirrorOf:        o.MirrorOf,
-		Bitdepth:        o.Bitdepth,
-		CM:              o.CM,
-		SDRBrightness:   o.SDRBrightness,
-		SDRSaturation:   o.SDRSaturation,
-		SDRMinLuminance: o.SDRMinLuminance,
-		SDRMaxLuminance: o.SDRMaxLuminance,
-		MinLuminance:    o.MinLuminance,
-		MaxLuminance:    o.MaxLuminance,
+		Key:               o.Key,
+		MatchKey:          o.MatchKey,
+		Name:              o.Name,
+		Make:              o.Make,
+		Model:             o.Model,
+		Serial:            o.Serial,
+		Enabled:           o.Enabled,
+		Mode:              o.DisplayMode(),
+		Width:             o.Width,
+		Height:            o.Height,
+		Refresh:           o.Refresh,
+		X:                 o.X,
+		Y:                 o.Y,
+		Scale:             o.Scale,
+		VRR:               o.VRR,
+		Transform:         o.Transform,
+		MirrorOf:          o.MirrorOf,
+		Bitdepth:          o.Bitdepth,
+		CM:                o.CM,
+		SDRBrightness:     o.SDRBrightness,
+		SDRSaturation:     o.SDRSaturation,
+		SDRMinLuminance:   o.SDRMinLuminance,
+		SDRMaxLuminance:   o.SDRMaxLuminance,
+		MinLuminance:      o.MinLuminance,
+		MaxLuminance:      o.MaxLuminance,
+		SupportsWideColor: o.SupportsWideColor,
+		SupportsHDR:       o.SupportsHDR,
+		MaxAvgLuminance:   o.MaxAvgLuminance,
+		SDREOTF:           o.SDREOTF,
+		ICC:               o.ICC,
 	}
 }
 
@@ -2608,6 +2683,17 @@ func vrrLabel(v int) string {
 	}
 }
 
+func triStateLabel(v int) string {
+	switch v {
+	case -1:
+		return "off"
+	case 1:
+		return "on"
+	default:
+		return "auto"
+	}
+}
+
 func transformLabel(v int) string {
 	switch v {
 	case 0:
@@ -2779,11 +2865,16 @@ var layoutFields = []string{
 	"Mirror",
 	// Advanced fields (index baseFieldCount+)
 	"SDR Bright",
-	"SDR Satur",
+	"SDR Sat",
 	"SDR Min Lum",
 	"SDR Max Lum",
-	"Min Lumin",
-	"Max Lumin",
+	"SDR Curve",
+	"Min Lum",
+	"Max Lum",
+	"Max Avg Lum",
+	"Force Wide",
+	"Force HDR",
+	"ICC Path",
 }
 
 const baseFieldCount = 10

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -218,7 +218,6 @@ type Model struct {
 	snap          *snapHintState
 	snapSeq       int
 
-	showAdvanced     bool
 	status           string
 	statusErr        bool
 	dirty            bool
@@ -509,18 +508,13 @@ func (m *Model) updateLayoutKeys(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 
 	switch msg.String() {
 	case "up", "k":
-		m.inspectorField = clampIndex(m.inspectorField-1, m.visibleFieldCount())
+		m.inspectorField = clampIndex(m.inspectorField-1, len(layoutFields))
 	case "down", "j":
-		m.inspectorField = clampIndex(m.inspectorField+1, m.visibleFieldCount())
+		m.inspectorField = clampIndex(m.inspectorField+1, len(layoutFields))
 	case "left", "h", "-", "_":
 		m.adjustInspectorField(-1)
 	case "right", "l", "+", "=":
 		m.adjustInspectorField(1)
-	case "x":
-		m.showAdvanced = !m.showAdvanced
-		if !m.showAdvanced && m.inspectorField >= baseFieldCount {
-			m.inspectorField = baseFieldCount - 1
-		}
 	case " ", "enter":
 		return m, m.activateInspectorField()
 	default:
@@ -1113,13 +1107,6 @@ func (m Model) compactLayoutHeights(total int) (int, int) {
 	return max(2, canvas), max(1, inspector)
 }
 
-func (m Model) visibleFieldCount() int {
-	if m.showAdvanced {
-		return len(layoutFields)
-	}
-	return baseFieldCount
-}
-
 func (m Model) inspectorFieldLines(output editableOutput, innerWidth int, compact bool) []string {
 	if compact {
 		return m.compactInspectorFieldLines(output, innerWidth)
@@ -1131,14 +1118,8 @@ func (m Model) inspectorFieldLines(output editableOutput, innerWidth int, compac
 		labelWidth = 8
 	}
 
-	fieldCount := m.visibleFieldCount()
-	lines := make([]string, 0, fieldCount+1)
-	for idx := 0; idx < fieldCount; idx++ {
-		if idx == baseFieldCount {
-			lines = append(lines, "")
-			lines = append(lines, m.styles.header.Render("▼ Advanced")+" "+m.styles.subtle.Render("(x)"))
-		}
-
+	lines := make([]string, 0, len(layoutFields))
+	for idx := range layoutFields {
 		labelText := layoutFields[idx]
 		if shortLabels {
 			labelText = layoutFieldShortLabel(idx)
@@ -1150,11 +1131,6 @@ func (m Model) inspectorFieldLines(output editableOutput, innerWidth int, compac
 		}
 		label := m.styles.label.Render(fmt.Sprintf("%-*s", labelWidth, labelText))
 		lines = append(lines, fmt.Sprintf("%s %s", label, value))
-	}
-
-	if !m.showAdvanced {
-		toggle := m.styles.subtle.Render("▶ Advanced (x)")
-		lines = append(lines, "", toggle)
 	}
 
 	return lines
@@ -1337,7 +1313,7 @@ func (m *Model) loadLiveState() {
 		m.selectedOutput = outputIndexByKey(m.editOutputs, selectedKey)
 	}
 	m.selectedOutput = clampIndex(m.selectedOutput, len(m.editOutputs))
-	m.inspectorField = clampIndex(m.inspectorField, m.visibleFieldCount())
+	m.inspectorField = clampIndex(m.inspectorField, len(layoutFields))
 	m.picker = nil
 	m.input = nil
 	m.drag = nil
@@ -1395,7 +1371,7 @@ func (m *Model) recoverMirroredIdentity() {
 func (m *Model) syncSelections() {
 	m.selectedOutput = clampIndex(m.selectedOutput, len(m.editOutputs))
 	m.selectedProfile = clampIndex(m.selectedProfile, len(m.profiles))
-	m.inspectorField = clampIndex(m.inspectorField, m.visibleFieldCount())
+	m.inspectorField = clampIndex(m.inspectorField, len(layoutFields))
 	m.workspaceEdit.SelectedField = clampIndex(m.workspaceEdit.SelectedField, len(workspaceFields))
 	m.workspaceEdit.SelectedOrder = clampIndex(m.workspaceEdit.SelectedOrder, len(m.workspaceEdit.MonitorOrder))
 }
@@ -2863,7 +2839,6 @@ var layoutFields = []string{
 	"Position X",
 	"Position Y",
 	"Mirror",
-	// Advanced fields (index baseFieldCount+)
 	"SDR Bright",
 	"SDR Sat",
 	"SDR Min Lum",
@@ -2876,8 +2851,6 @@ var layoutFields = []string{
 	"Force HDR",
 	"ICC Path",
 }
-
-const baseFieldCount = 10
 
 func layoutFieldShortLabel(field int) string {
 	switch field {

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -804,6 +804,68 @@ func (m Model) renderCanvas(width, height int) string {
 	return renderCanvasCells(grid)
 }
 
+// inspectorLayout is the single source of truth shared by renderInspectorPane
+// and inspectorFieldAt so their row math cannot drift.
+type inspectorLayout struct {
+	lines     []string
+	fieldRows map[int]int // field index → index into lines
+}
+
+func (m Model) buildInspectorLayout(output editableOutput, innerWidth int, compact bool) inspectorLayout {
+	lines := []string{m.styles.header.Render("Selected Monitor")}
+
+	if compact {
+		info := fmt.Sprintf("%s  %s  %s", output.Name, output.displayModelLabel(), output.DisplayMode())
+		lines = append(lines, m.styles.subtle.Render(fitString(info, innerWidth)))
+	} else {
+		lines = append(lines, "")
+		lines = append(lines, m.styles.header.Render("Info"))
+		lines = append(lines, m.inspectorDetailLines(output)...)
+	}
+
+	lines = append(lines, "", m.styles.header.Render("Preferences"))
+
+	labelWidth := 12
+	shortLabels := compact || innerWidth < 34
+	if shortLabels {
+		labelWidth = 11
+	}
+
+	fieldRows := make(map[int]int, len(layoutFields))
+	for idx := range layoutFields {
+		if idx == advancedFieldStart {
+			lines = append(lines, "")
+		}
+		labelText := layoutFields[idx]
+		if shortLabels {
+			labelText = layoutFieldShortLabel(idx)
+		}
+		value := m.styles.value.Render(m.layoutFieldValue(output, idx))
+		if m.layoutFocus == layoutFocusInspector && idx == m.inspectorField && m.tab == tabLayout {
+			value = m.styles.focused.Render(value)
+		}
+		label := m.styles.label.Render(fmt.Sprintf("%-*s", labelWidth, labelText))
+		fieldRows[idx] = len(lines)
+		lines = append(lines, fmt.Sprintf("%s %s", label, value))
+	}
+
+	return inspectorLayout{lines: lines, fieldRows: fieldRows}
+}
+
+func inspectorScrollOffset(totalLines, selectedLine, height int) int {
+	if height <= 0 || selectedLine < height {
+		return 0
+	}
+	offset := selectedLine - height + 1
+	if offset < 0 {
+		offset = 0
+	}
+	if offset >= totalLines {
+		offset = totalLines - 1
+	}
+	return offset
+}
+
 func (m Model) renderInspectorPane(width int, height int, compact bool) string {
 	panel := m.styles.inactivePane
 	if m.layoutFocus == layoutFocusInspector && m.tab == tabLayout {
@@ -812,57 +874,26 @@ func (m Model) renderInspectorPane(width int, height int, compact bool) string {
 	innerWidth := max(1, width-panel.GetHorizontalFrameSize())
 	innerHeight := max(1, height-panel.GetVerticalFrameSize())
 
-	lines := []string{m.styles.header.Render("Selected Monitor")}
 	if len(m.editOutputs) == 0 {
-		lines = append(lines, "(none)")
+		lines := []string{m.styles.header.Render("Selected Monitor"), "(none)"}
 		return panel.Width(innerWidth).Render(fitBlock(strings.Join(lines, "\n"), innerWidth, innerHeight))
 	}
 
-	output := m.editOutputs[m.selectedOutput]
+	layout := m.buildInspectorLayout(m.editOutputs[m.selectedOutput], innerWidth, compact)
+	lines := layout.lines
 
-	detailCount := 0
-	if compact {
-		// Compact info: one-line summary
-		info := fmt.Sprintf("%s  %s  %s", output.Name, output.displayModelLabel(), output.DisplayMode())
-		lines = append(lines, m.styles.subtle.Render(fitString(info, innerWidth)))
-	} else {
-		lines = append(lines, "")
-		// Info section
-		lines = append(lines, m.styles.header.Render("Info"))
-		detailLines := m.inspectorDetailLines(output)
-		detailCount = len(detailLines)
-		lines = append(lines, detailLines...)
-	}
-
-	// Preferences section
-	lines = append(lines, "")
-	lines = append(lines, m.styles.header.Render("Preferences"))
-	fieldLines := m.inspectorFieldLines(output, innerWidth, false)
-	lines = append(lines, fieldLines...)
-
-	if !compact && m.layoutFocus == layoutFocusInspector && m.tab == tabLayout {
-		// header(1) + blank(1) + Info(1) + details(N) + blank(1) + Preferences(1) = N+5
-		fieldBase := 5 + detailCount
-		selectedLine := fieldBase + m.inspectorField
-		if m.inspectorField >= advancedFieldStart {
-			selectedLine++ // spacer row before advanced
+	if m.layoutFocus == layoutFocusInspector && m.tab == tabLayout {
+		if row, ok := layout.fieldRows[m.inspectorField]; ok {
+			offset := inspectorScrollOffset(len(lines), row, innerHeight)
+			lines = lines[offset:]
 		}
-		lines = scrollLinesToFit(lines, selectedLine, innerHeight)
 	}
 
 	return panel.Width(innerWidth).Render(fitBlock(strings.Join(lines, "\n"), innerWidth, innerHeight))
 }
 
-// scrollLinesToFit trims leading lines so that the line at selectedLine is
-// within the first `height` rows. Returns lines unchanged if already visible.
 func scrollLinesToFit(lines []string, selectedLine, height int) []string {
-	if height <= 0 || selectedLine < height {
-		return lines
-	}
-	offset := selectedLine - height + 1
-	if offset >= len(lines) {
-		offset = len(lines) - 1
-	}
+	offset := inspectorScrollOffset(len(lines), selectedLine, height)
 	return lines[offset:]
 }
 
@@ -1132,102 +1163,6 @@ func (m Model) compactLayoutHeights(total int) (int, int) {
 		inspector = total - canvas
 	}
 	return max(2, canvas), max(1, inspector)
-}
-
-func (m Model) inspectorFieldLines(output editableOutput, innerWidth int, compact bool) []string {
-	if compact {
-		return m.compactInspectorFieldLines(output, innerWidth)
-	}
-
-	labelWidth := 12
-	shortLabels := innerWidth < 34
-	if shortLabels {
-		labelWidth = 8
-	}
-
-	lines := make([]string, 0, len(layoutFields)+1)
-	for idx := range layoutFields {
-		if idx == advancedFieldStart {
-			lines = append(lines, "")
-		}
-		labelText := layoutFields[idx]
-		if shortLabels {
-			labelText = layoutFieldShortLabel(idx)
-		}
-
-		value := m.styles.value.Render(m.layoutFieldValue(output, idx))
-		if m.layoutFocus == layoutFocusInspector && idx == m.inspectorField && m.tab == tabLayout {
-			value = m.styles.focused.Render(value)
-		}
-		label := m.styles.label.Render(fmt.Sprintf("%-*s", labelWidth, labelText))
-		lines = append(lines, fmt.Sprintf("%s %s", label, value))
-	}
-
-	return lines
-}
-
-func (m Model) compactInspectorFieldLines(output editableOutput, innerWidth int) []string {
-	switch {
-	case innerWidth >= 48:
-		return []string{
-			m.inspectorCompactFieldLine("Mode", 1, output),
-			joinInspectorTokens(
-				m.inspectorCompactFieldToken("On", 0, output),
-				m.inspectorCompactFieldToken("Scale", 2, output),
-				m.inspectorCompactFieldToken("VRR", 5, output),
-			),
-			joinInspectorTokens(
-				m.inspectorCompactFieldToken("Rot", 6, output),
-				m.inspectorCompactFieldToken("X", 7, output),
-				m.inspectorCompactFieldToken("Y", 8, output),
-			),
-			m.inspectorCompactFieldLine("Mirror", 9, output),
-		}
-	case innerWidth >= 36:
-		return []string{
-			m.inspectorCompactFieldLine("Mode", 1, output),
-			joinInspectorTokens(
-				m.inspectorCompactFieldToken("On", 0, output),
-				m.inspectorCompactFieldToken("Scale", 2, output),
-			),
-			joinInspectorTokens(
-				m.inspectorCompactFieldToken("VRR", 5, output),
-				m.inspectorCompactFieldToken("Rot", 6, output),
-			),
-			joinInspectorTokens(
-				m.inspectorCompactFieldToken("X", 7, output),
-				m.inspectorCompactFieldToken("Y", 8, output),
-			),
-			m.inspectorCompactFieldLine("Mirror", 9, output),
-		}
-	default:
-		return []string{
-			m.inspectorCompactFieldLine("Mode", 1, output),
-			m.inspectorCompactFieldLine("On", 0, output),
-			m.inspectorCompactFieldLine("Scale", 2, output),
-			joinInspectorTokens(
-				m.inspectorCompactFieldToken("VRR", 5, output),
-				m.inspectorCompactFieldToken("Rot", 6, output),
-			),
-			joinInspectorTokens(
-				m.inspectorCompactFieldToken("X", 7, output),
-				m.inspectorCompactFieldToken("Y", 8, output),
-			),
-			m.inspectorCompactFieldLine("Mirror", 9, output),
-		}
-	}
-}
-
-func (m Model) inspectorCompactFieldLine(label string, field int, output editableOutput) string {
-	return joinInspectorTokens(m.inspectorCompactFieldToken(label, field, output))
-}
-
-func (m Model) inspectorCompactFieldToken(label string, field int, output editableOutput) string {
-	value := m.styles.value.Render(m.layoutFieldValue(output, field))
-	if m.layoutFocus == layoutFocusInspector && field == m.inspectorField && m.tab == tabLayout {
-		value = m.styles.focused.Render(value)
-	}
-	return lipgloss.JoinHorizontal(lipgloss.Left, m.styles.label.Render(label), " ", value)
 }
 
 func (m Model) inspectorDetailLines(output editableOutput) []string {
@@ -2619,17 +2554,6 @@ func fitString(value string, width int) string {
 		return string(runes[:width])
 	}
 	return string(runes[:width-3]) + "..."
-}
-
-func joinInspectorTokens(tokens ...string) string {
-	parts := make([]string, 0, len(tokens))
-	for _, token := range tokens {
-		if token == "" {
-			continue
-		}
-		parts = append(parts, token)
-	}
-	return strings.Join(parts, "  ")
 }
 
 func blankFallback(value string, fallback string) string {

--- a/internal/tui/model_test.go
+++ b/internal/tui/model_test.go
@@ -951,8 +951,8 @@ func TestRenderMainFitsShortTerminalHeight(t *testing.T) {
 	if height := lipgloss.Height(view); height != m.height {
 		t.Fatalf("expected short main view to fill height %d, got %d", m.height, height)
 	}
-	if !strings.Contains(view, "Selected Monitor") {
-		t.Fatalf("expected Selected Monitor to remain visible, got:\n%s", view)
+	if !strings.Contains(view, "Preferences") {
+		t.Fatalf("expected Preferences section to be visible in inspector, got:\n%s", view)
 	}
 }
 
@@ -1534,5 +1534,88 @@ func TestScrollLinesToFit(t *testing.T) {
 				t.Errorf("first line = %q, want %q", got[0], tt.wantFirst)
 			}
 		})
+	}
+}
+
+func TestBuildInspectorLayoutMapsAllFields(t *testing.T) {
+	m := Model{
+		styles: newStyles(),
+		editOutputs: []editableOutput{{
+			Key:             "test",
+			Name:            "DP-1",
+			Enabled:         true,
+			Modes:           []string{"3840x2160@144Hz"},
+			ModeIndex:       0,
+			Width:           3840,
+			Height:          2160,
+			Refresh:         144,
+			Scale:           1,
+			ActiveWorkspace: "1",
+		}},
+	}
+
+	for _, compact := range []bool{false, true} {
+		name := "full"
+		if compact {
+			name = "compact"
+		}
+		t.Run(name, func(t *testing.T) {
+			layout := m.buildInspectorLayout(m.editOutputs[0], 60, compact)
+			if len(layout.fieldRows) != len(layoutFields) {
+				t.Fatalf("fieldRows has %d entries, want %d", len(layout.fieldRows), len(layoutFields))
+			}
+			for idx := range layoutFields {
+				row, ok := layout.fieldRows[idx]
+				if !ok {
+					t.Errorf("field %d (%s) missing from fieldRows", idx, layoutFields[idx])
+					continue
+				}
+				if row < 0 || row >= len(layout.lines) {
+					t.Errorf("field %d row %d out of range [0, %d)", idx, row, len(layout.lines))
+				}
+			}
+		})
+	}
+}
+
+func TestBuildInspectorLayoutSpacerBeforeAdvanced(t *testing.T) {
+	m := Model{
+		styles: newStyles(),
+		editOutputs: []editableOutput{{
+			Key:     "test",
+			Name:    "DP-1",
+			Enabled: true,
+			Scale:   1,
+		}},
+	}
+	layout := m.buildInspectorLayout(m.editOutputs[0], 60, false)
+
+	lastBase := layout.fieldRows[advancedFieldStart-1]
+	firstAdvanced := layout.fieldRows[advancedFieldStart]
+	if firstAdvanced-lastBase < 2 {
+		t.Errorf("expected spacer row between field %d and %d: got rows %d and %d", advancedFieldStart-1, advancedFieldStart, lastBase, firstAdvanced)
+	}
+}
+
+func TestBuildInspectorLayoutUniqueRows(t *testing.T) {
+	m := Model{
+		styles: newStyles(),
+		editOutputs: []editableOutput{{
+			Key:     "test",
+			Name:    "DP-1",
+			Enabled: true,
+			Scale:   1,
+		}},
+	}
+	for _, compact := range []bool{false, true} {
+		layout := m.buildInspectorLayout(m.editOutputs[0], 60, compact)
+		seen := make(map[int]int)
+		for idx := range layoutFields {
+			row := layout.fieldRows[idx]
+			if other, exists := seen[row]; exists {
+				t.Errorf("compact=%v: field %d and %d share row %d", compact, other, idx, row)
+			}
+			seen[row] = idx
+		}
 	}
 }

--- a/internal/tui/model_test.go
+++ b/internal/tui/model_test.go
@@ -1484,3 +1484,55 @@ func TestLayoutMoveVimKeysMatchArrows(t *testing.T) {
 		}
 	}
 }
+
+func TestNumericInputWidthFor(t *testing.T) {
+	m := Model{width: 120}
+	iccWidth := m.numericInputWidthFor(numericInputICC)
+	scaleWidth := m.numericInputWidthFor(numericInputScale)
+	floatWidth := m.numericInputWidthFor(numericInputFloat)
+	intWidth := m.numericInputWidthFor(numericInputInt)
+
+	if iccWidth <= scaleWidth {
+		t.Errorf("ICC width (%d) should be wider than scale width (%d)", iccWidth, scaleWidth)
+	}
+	if iccWidth < 20 || iccWidth > 60 {
+		t.Errorf("ICC width %d outside expected range [20, 60]", iccWidth)
+	}
+	if scaleWidth < 8 || scaleWidth > 12 {
+		t.Errorf("Scale width %d outside expected range [8, 12]", scaleWidth)
+	}
+	if floatWidth != scaleWidth || intWidth != scaleWidth {
+		t.Errorf("float/int widths should match scale: float=%d int=%d scale=%d", floatWidth, intWidth, scaleWidth)
+	}
+}
+
+func TestScrollLinesToFit(t *testing.T) {
+	lines := []string{"0", "1", "2", "3", "4", "5", "6", "7", "8", "9"}
+
+	tests := []struct {
+		name         string
+		selectedLine int
+		height       int
+		wantFirst    string
+		wantLen      int
+	}{
+		{"selected at top, fits", 0, 10, "0", 10},
+		{"selected inside viewport", 3, 10, "0", 10},
+		{"selected at last visible row", 9, 10, "0", 10},
+		{"selected just past viewport", 5, 5, "1", 9},
+		{"selected at end", 9, 5, "5", 5},
+		{"height zero returns unchanged", 9, 0, "0", 10},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := scrollLinesToFit(lines, tt.selectedLine, tt.height)
+			if len(got) != tt.wantLen {
+				t.Errorf("len = %d, want %d", len(got), tt.wantLen)
+			}
+			if got[0] != tt.wantFirst {
+				t.Errorf("first line = %q, want %q", got[0], tt.wantFirst)
+			}
+		})
+	}
+}

--- a/internal/tui/model_test.go
+++ b/internal/tui/model_test.go
@@ -459,13 +459,13 @@ func TestActivateInspectorFieldOpensEditors(t *testing.T) {
 		t.Fatalf("expected numeric input to open, got mode %v input %+v", base.mode, base.input)
 	}
 
-	base.inspectorField = 5
+	base.inspectorField = 7
 	base.activateInspectorField()
 	if base.mode != modeNumericInput || base.input == nil || base.input.Kind != numericInputPositionX {
 		t.Fatalf("expected position X input to open, got mode %v input %+v", base.mode, base.input)
 	}
 
-	base.inspectorField = 6
+	base.inspectorField = 8
 	base.activateInspectorField()
 	if base.mode != modeNumericInput || base.input == nil || base.input.Kind != numericInputPositionY {
 		t.Fatalf("expected position Y input to open, got mode %v input %+v", base.mode, base.input)


### PR DESCRIPTION
## Summary

- Capture and restore additional `monitorv2` fields that were previously
  lost on save/apply: `bitdepth`, `cm`, `sdrbrightness`, `sdrsaturation`,
  `sdr_min_luminance`, `sdr_max_luminance`, `min_luminance`, `max_luminance`
- Change VRR from `bool` to a custom `VRRMode` type that unmarshals both
  `true/false` and `0/1/2` from hyprctl JSON, enabling fullscreen-only (2)
- Add Bit Depth and Color Mgmt to the TUI inspector Preferences section
- Add collapsible Advanced section (`x` key) for SDR/luminance settings
- Preserve VRR and EDID luminance values through TUI refreshes, since
  hyprctl cannot report them accurately
- Skip VRR post-apply validation (hyprctl reports active state as a bool,
  not the configured mode)

Closes #9

## Backward compatibility

- All new profile fields use `omitempty` (except `sdr_min_luminance` and
  `min_luminance` where 0 is a valid value). Old profiles load without errors.
- `VRRMode` handles both `bool` and `int` — existing profiles and hyprctl
  output both work.
- Monitor state hash format changed (`vrr=%t` → `vrr=%d`), causing a
  one-time daemon re-apply on upgrade — harmless.

## Screenshots

### Preferences with Bit Depth, Color Mgmt (Advanced collapsed)

<img width="2593" height="1540" alt="image" src="https://github.com/user-attachments/assets/5db5a4cd-11ca-4c71-93b5-1d027a1d7a89" />

### Advanced section expanded (SDR/luminance settings)

<img width="2596" height="1523" alt="image" src="https://github.com/user-attachments/assets/7329e21a-e349-4582-b136-d3bf2d5a3f3d" />