### PR TITLE
Add optional script to be executed post apply

### DIFF
--- a/cmd/hyprmoncfg/main.go
+++ b/cmd/hyprmoncfg/main.go
@@ -3,6 +3,7 @@ package main
 import (
 	"bufio"
 	"context"
+	"errors"
 	"fmt"
 	"os"
 	"strings"
@@ -133,6 +134,7 @@ func newSaveCmd(configDir *string) *cobra.Command {
 		Short: "Save current monitor state as profile",
 		Args:  cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
+			name := args[0]
 			client, store, err := bootstrap(*configDir)
 			if err != nil {
 				return err
@@ -147,7 +149,12 @@ func newSaveCmd(configDir *string) *cobra.Command {
 			if err != nil {
 				return err
 			}
-			p := profile.FromState(args[0], monitors, rules)
+			p := profile.FromState(name, monitors, rules)
+			existing, err := store.Load(name)
+			if err != nil && !errors.Is(err, os.ErrNotExist) {
+				return err
+			}
+			p.Exec = existing.Exec
 			if err := store.Save(p); err != nil {
 				return err
 			}

--- a/cmd/hyprmoncfg/main.go
+++ b/cmd/hyprmoncfg/main.go
@@ -189,6 +189,15 @@ func newApplyCmd(configDir *string, monitorsConf *string, hyprConfig *string) *c
 				return err
 			}
 
+			var (
+				applyMode     = apply.ApplyModeInteractive
+				isInterActive = confirmTimeout > 0
+			)
+
+			if !isInterActive {
+				applyMode = apply.ApplyModeNonInteractive
+			}
+
 			engine := apply.Engine{
 				Client:             client,
 				MonitorsConfPath:   *monitorsConf,
@@ -197,13 +206,13 @@ func newApplyCmd(configDir *string, monitorsConf *string, hyprConfig *string) *c
 					fmt.Printf(format, args...)
 				},
 			}
-			snapshot, err := engine.Apply(ctx, p, monitors, apply.ApplyModeInteractive)
+			snapshot, err := engine.Apply(ctx, p, monitors, applyMode)
 			if err != nil {
 				return err
 			}
 			fmt.Printf("Applied profile %q\n", p.Name)
 
-			if confirmTimeout <= 0 {
+			if !isInterActive {
 				return nil
 			}
 
@@ -214,7 +223,10 @@ func newApplyCmd(configDir *string, monitorsConf *string, hyprConfig *string) *c
 			if keep {
 				fmt.Println("Configuration kept")
 
-				err = engine.PostApply(ctx, p)
+				postApplyCtx, cancel := context.WithTimeout(context.Background(), 8*time.Second)
+				defer cancel()
+
+				err = engine.PostApply(postApplyCtx, p)
 				if err != nil {
 					fmt.Printf("Post-apply failed for %s: %v\n", p.Name, err)
 				}

--- a/cmd/hyprmoncfg/main.go
+++ b/cmd/hyprmoncfg/main.go
@@ -190,7 +190,7 @@ func newApplyCmd(configDir *string, monitorsConf *string, hyprConfig *string) *c
 					fmt.Printf(format, args...)
 				},
 			}
-			snapshot, err := engine.Apply(ctx, p, monitors)
+			snapshot, err := engine.Apply(ctx, p, monitors, apply.ApplyModeInteractive)
 			if err != nil {
 				return err
 			}
@@ -206,6 +206,12 @@ func newApplyCmd(configDir *string, monitorsConf *string, hyprConfig *string) *c
 			}
 			if keep {
 				fmt.Println("Configuration kept")
+
+				err = engine.PostApply(ctx, p)
+				if err != nil {
+					fmt.Printf("Post-apply failed for %s: %v\n", p.Name, err)
+				}
+
 				return nil
 			}
 

--- a/cmd/hyprmoncfg/main.go
+++ b/cmd/hyprmoncfg/main.go
@@ -186,6 +186,9 @@ func newApplyCmd(configDir *string, monitorsConf *string, hyprConfig *string) *c
 				Client:             client,
 				MonitorsConfPath:   *monitorsConf,
 				HyprlandConfigPath: *hyprConfig,
+				Logf: func(format string, args ...any) {
+					fmt.Printf(format, args...)
+				},
 			}
 			snapshot, err := engine.Apply(ctx, p, monitors)
 			if err != nil {

--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/crmne/hyprmoncfg
 go 1.26.1
 
 require (
+	github.com/buildkite/shellwords v1.0.1
 	github.com/charmbracelet/bubbles v1.0.0
 	github.com/charmbracelet/bubbletea v1.3.10
 	github.com/charmbracelet/lipgloss v1.1.0

--- a/go.sum
+++ b/go.sum
@@ -4,6 +4,8 @@ github.com/aymanbagabas/go-osc52/v2 v2.0.1 h1:HwpRHbFMcZLEVr42D4p7XBqjyuxQH5SMiE
 github.com/aymanbagabas/go-osc52/v2 v2.0.1/go.mod h1:uYgXzlJ7ZpABp8OJ+exZzJJhRNQ2ASbcXHWsFqH8hp8=
 github.com/aymanbagabas/go-udiff v0.3.1 h1:LV+qyBQ2pqe0u42ZsUEtPiCaUoqgA9gYRDs3vj1nolY=
 github.com/aymanbagabas/go-udiff v0.3.1/go.mod h1:G0fsKmG+P6ylD0r6N/KgQD/nWzgfnl8ZBcNLgcbrw8E=
+github.com/buildkite/shellwords v1.0.1 h1:88OjMbEBf+EliVB0tizXJynpAM2CKOvYwepg5n8O70M=
+github.com/buildkite/shellwords v1.0.1/go.mod h1:so0eQnTxgbo58CTYX+4BCx5UuMzvRha9dcKdCKl6NV4=
 github.com/charmbracelet/bubbles v1.0.0 h1:12J8/ak/uCZEMQ6KU7pcfwceyjLlWsDLAxB5fXonfvc=
 github.com/charmbracelet/bubbles v1.0.0/go.mod h1:9d/Zd5GdnauMI5ivUIVisuEm3ave1XwXtD1ckyV6r3E=
 github.com/charmbracelet/bubbletea v1.3.10 h1:otUDHWMMzQSB0Pkc87rm691KZ3SWa4KUlvF9nRvCICw=

--- a/internal/apply/apply.go
+++ b/internal/apply/apply.go
@@ -4,12 +4,21 @@ import (
 	"context"
 	"fmt"
 	"math"
+	"os/exec"
 	"strconv"
 	"strings"
 
+	"github.com/buildkite/shellwords"
 	"github.com/crmne/hyprmoncfg/internal/config"
 	"github.com/crmne/hyprmoncfg/internal/hypr"
 	"github.com/crmne/hyprmoncfg/internal/profile"
+)
+
+type applyMode int
+
+const (
+	ApplyModeInteractive applyMode = iota
+	ApplyModeNonInteractive
 )
 
 type Engine struct {
@@ -119,7 +128,12 @@ func SnapshotCommands(monitors []hypr.Monitor) []string {
 	return commands
 }
 
-func (e Engine) Apply(ctx context.Context, p profile.Profile, monitors []hypr.Monitor) (RevertState, error) {
+func (e Engine) Apply(ctx context.Context, p profile.Profile, monitors []hypr.Monitor, modearg ...applyMode) (RevertState, error) {
+	mode := ApplyModeNonInteractive
+	if len(modearg) > 0 {
+		mode = modearg[0]
+	}
+
 	if e.Client == nil {
 		return RevertState{}, fmt.Errorf("nil hypr client")
 	}
@@ -191,7 +205,39 @@ func (e Engine) Apply(ctx context.Context, p profile.Profile, monitors []hypr.Mo
 		return RevertState{}, err
 	}
 
+	if mode == ApplyModeNonInteractive {
+		if err = e.PostApply(ctx, p); err != nil {
+			return RevertState{}, err
+		}
+	}
+
 	return revertState, nil
+}
+
+func (e Engine) PostApply(ctx context.Context, target profile.Profile) error {
+	if target.Exec == "" {
+		return nil
+	}
+
+	parts, err := shellwords.Split(target.Exec)
+	if err != nil {
+		return fmt.Errorf("split shellwords: %w", err)
+	}
+
+	var args []string
+	command := parts[0]
+
+	if len(parts) > 1 {
+		args = parts[1:]
+	}
+
+	cmd := exec.CommandContext(ctx, command, args...)
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		return fmt.Errorf("failed to exec script: %w (%s)", err, strings.TrimSpace(string(out)))
+	}
+
+	return nil
 }
 
 func (e Engine) Revert(ctx context.Context, state RevertState) error {

--- a/internal/apply/apply.go
+++ b/internal/apply/apply.go
@@ -25,6 +25,7 @@ type Engine struct {
 	Client             *hypr.Client
 	MonitorsConfPath   string
 	HyprlandConfigPath string
+	Logf               func(format string, args ...any)
 }
 
 type RevertState struct {
@@ -207,7 +208,7 @@ func (e Engine) Apply(ctx context.Context, p profile.Profile, monitors []hypr.Mo
 
 	if mode == ApplyModeNonInteractive {
 		if err = e.PostApply(ctx, p); err != nil {
-			return RevertState{}, err
+			e.Logf("post apply: %v", err)
 		}
 	}
 
@@ -215,11 +216,13 @@ func (e Engine) Apply(ctx context.Context, p profile.Profile, monitors []hypr.Mo
 }
 
 func (e Engine) PostApply(ctx context.Context, target profile.Profile) error {
-	if target.Exec == "" {
+	postApplyCommand := strings.TrimSpace(target.Exec)
+
+	if postApplyCommand == "" {
 		return nil
 	}
 
-	parts, err := shellwords.Split(target.Exec)
+	parts, err := shellwords.Split(postApplyCommand)
 	if err != nil {
 		return fmt.Errorf("split shellwords: %w", err)
 	}

--- a/internal/apply/apply_test.go
+++ b/internal/apply/apply_test.go
@@ -3,6 +3,8 @@ package apply
 import (
 	"context"
 	"encoding/json"
+	"errors"
+	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
@@ -11,6 +13,18 @@ import (
 	"github.com/crmne/hyprmoncfg/internal/hypr"
 	"github.com/crmne/hyprmoncfg/internal/profile"
 )
+
+var monitors = []hypr.Monitor{
+	{Name: "DP-1", Description: "Microstep MPG321UR-QD", Make: "Microstep", Model: "MPG321UR-QD", Serial: "A1", Width: 3840, Height: 2160, RefreshRate: 143.99, Scale: 1, VRR: hypr.VRRMode(1)},
+	{Name: "eDP-1", Description: "Samsung Display Corp. ATNA60CL10-0", Make: "Samsung Display Corp.", Model: "ATNA60CL10-0", Serial: "B2", Width: 2880, Height: 1800, RefreshRate: 120, X: 3840, Scale: 1},
+}
+
+func newTestProfile() profile.Profile {
+	return profile.New("desk", []profile.OutputConfig{
+		{Key: monitors[0].HardwareKey(), Name: monitors[0].Name, Enabled: true, Width: 3840, Height: 2160, Refresh: 143.99, X: 0, Y: 0, Scale: 1, VRR: 1},
+		{Key: monitors[1].HardwareKey(), Name: monitors[1].Name, Enabled: true, Width: 2880, Height: 1800, Refresh: 120, X: 3840, Y: 0, Scale: 1},
+	})
+}
 
 func TestCommandsForProfile(t *testing.T) {
 	mon := hypr.Monitor{Name: "DP-1", Make: "Dell", Model: "U2720Q", Serial: "A1"}
@@ -435,8 +449,123 @@ func TestSnapshotCommandsMirror(t *testing.T) {
 }
 
 func TestEngineApplyAndRevertReplayWorkspacePlacement(t *testing.T) {
+	p := 	newTestProfile()
+	p.Workspaces = profile.WorkspaceSettings{
+		Enabled:  true,
+		Strategy: profile.WorkspaceStrategyManual,
+		Rules: []profile.WorkspaceRule{
+			{Workspace: "1", OutputKey: monitors[0].HardwareKey(), OutputName: monitors[0].Name, Default: true, Persistent: true},
+			{Workspace: "2", OutputKey: monitors[1].HardwareKey(), OutputName: monitors[1].Name, Default: true, Persistent: true},
+		},
+	}
+
+	engine, logPath, err := initTestEngine(t)
+	if err != nil {
+		t.Fatalf("init test engine: %v", err)
+	}
+
+	ctx := context.Background()
+	snapshot, err := engine.Apply(ctx, p, monitors)
+	if err != nil {
+		t.Fatalf("apply failed: %v", err)
+	}
+	if err := engine.Revert(ctx, snapshot); err != nil {
+		t.Fatalf("revert failed: %v", err)
+	}
+
+	logBytes, err := os.ReadFile(logPath)
+	if err != nil {
+		t.Fatalf("read hyprctl log: %v", err)
+	}
+	log := string(logBytes)
+
+	for _, want := range []string{
+		"reload",
+		"BATCH:keyword workspace 1, monitor:desc:Microstep MPG321UR-QD, default:true, persistent:true ; dispatch moveworkspacetomonitor 1 DP-1 ; keyword workspace 2, monitor:desc:Samsung Display Corp. ATNA60CL10-0, default:true, persistent:true ; dispatch moveworkspacetomonitor 2 eDP-1",
+		"BATCH:keyword monitor DP-1,3840x2160@143.99,0x0,1,transform,0,vrr,1 ; keyword monitor eDP-1,2880x1800@120.00,3840x0,1,transform,0,vrr,0 ; keyword workspace 1, monitor:desc:Samsung Display Corp. ATNA60CL10-0, default:true, persistent:true ; keyword workspace 2, monitor:desc:Microstep MPG321UR-QD, default:true, persistent:true ; dispatch moveworkspacetomonitor 1 eDP-1 ; dispatch moveworkspacetomonitor 2 DP-1",
+	} {
+		if !strings.Contains(log, want) {
+			t.Fatalf("expected hyprctl log to contain %q, got:\n%s", want, log)
+		}
+	}
+}
+
+func TestEnginePostApply(t *testing.T) {
+	engine, _, err := initTestEngine(t)
+	if err != nil {
+		t.Fatalf("init test engine: %v", err)
+	}
+
 	dir := t.TempDir()
-	logPath := filepath.Join(dir, "hyprctl.log")
+	execPath := filepath.Join(dir, "post_apply.sh")
+
+	execScript := `#!/bin/bash
+	OUT_FILE="$1"
+
+	if [ -z "$OUT_FILE" ]; then
+	  exit 1
+	fi
+
+	touch "$OUT_FILE"`
+
+	if err := os.WriteFile(execPath, []byte(execScript), 0o755); err != nil {
+		t.Fatalf("write exec script: %v", err)
+	}
+
+	ctx := context.Background()
+
+	testcases := []struct {
+		Name            string
+		Mode            applyMode
+		OutFile         string
+		ShouldTouchFile bool
+	}{
+		{
+			Name:    "should_not_call_post_exec_when_interactive",
+			Mode:    ApplyModeInteractive,
+			OutFile: filepath.Join(dir, "8d0f0878-6240-4deb-ac28-b5f2f251a606"),
+		},
+		{
+			Name:            "should_call_post_exec_when_noninteractive",
+			Mode:            ApplyModeNonInteractive,
+			OutFile:         filepath.Join(dir, "b33b65c7-2c39-4df6-b56b-3ff64c816ff6"),
+			ShouldTouchFile: true,
+		},
+	}
+
+	p := newTestProfile()
+
+	for _, tc := range testcases {
+		t.Run(tc.Name, func(st *testing.T) {
+
+			p.Exec = fmt.Sprintf("%s %s", execPath, tc.OutFile)
+
+			_, err := engine.Apply(ctx, p, monitors, tc.Mode)
+			if err != nil {
+				st.Fatalf("%s: apply: %v", tc.Name, err)
+			}
+
+			var fileExists bool
+
+			_, err = os.Stat(tc.OutFile)
+			if err != nil {
+				if !errors.Is(err, os.ErrNotExist) {
+					st.Fatalf("stat file: %v", err)
+				}
+			} else {
+				fileExists = true
+			}
+
+			if fileExists != tc.ShouldTouchFile {
+				st.Fatalf("expected file to exist: %v. File exists: %v.", tc.ShouldTouchFile, fileExists)
+			}
+		})
+	}
+}
+
+func initTestEngine(t *testing.T) (engine *Engine, logPath string, err error) {
+	dir := t.TempDir()
+	logPath = filepath.Join(dir, "hyprctl.log")
 	monitorsConfPath := filepath.Join(dir, "monitors.conf")
 	hyprlandConfigPath := filepath.Join(dir, "hyprland.conf")
 	hyprctlPath := filepath.Join(dir, "hyprctl")
@@ -500,7 +629,8 @@ exit 1
 
 	client, err := hypr.NewClient()
 	if err != nil {
-		t.Fatalf("new hypr client: %v", err)
+		err = fmt.Errorf("new hypr client: %w", err)
+		return
 	}
 
 	monitors := []hypr.Monitor{
@@ -520,36 +650,13 @@ exit 1
 		},
 	}
 
-	engine := Engine{
+	engine = &Engine{
 		Client:             client,
 		MonitorsConfPath:   monitorsConfPath,
 		HyprlandConfigPath: hyprlandConfigPath,
 	}
 
-	ctx := context.Background()
-	snapshot, err := engine.Apply(ctx, p, monitors)
-	if err != nil {
-		t.Fatalf("apply failed: %v", err)
-	}
-	if err := engine.Revert(ctx, snapshot); err != nil {
-		t.Fatalf("revert failed: %v", err)
-	}
-
-	logBytes, err := os.ReadFile(logPath)
-	if err != nil {
-		t.Fatalf("read hyprctl log: %v", err)
-	}
-	log := string(logBytes)
-
-	for _, want := range []string{
-		"reload",
-		"BATCH:keyword workspace 1, monitor:desc:Microstep MPG321UR-QD, default:true, persistent:true ; dispatch moveworkspacetomonitor 1 DP-1 ; keyword workspace 2, monitor:desc:Samsung Display Corp. ATNA60CL10-0, default:true, persistent:true ; dispatch moveworkspacetomonitor 2 eDP-1",
-		"BATCH:keyword monitor DP-1,3840x2160@143.99,0x0,1,transform,0,vrr,1 ; keyword monitor eDP-1,2880x1800@120.00,3840x0,1,transform,0,vrr,0 ; keyword workspace 1, monitor:desc:Samsung Display Corp. ATNA60CL10-0, default:true, persistent:true ; keyword workspace 2, monitor:desc:Microstep MPG321UR-QD, default:true, persistent:true ; dispatch moveworkspacetomonitor 1 eDP-1 ; dispatch moveworkspacetomonitor 2 DP-1",
-	} {
-		if !strings.Contains(log, want) {
-			t.Fatalf("expected hyprctl log to contain %q, got:\n%s", want, log)
-		}
-	}
+	return
 }
 
 func TestVRRModeUnmarshal(t *testing.T) {

--- a/internal/apply/apply_test.go
+++ b/internal/apply/apply_test.go
@@ -449,7 +449,7 @@ func TestSnapshotCommandsMirror(t *testing.T) {
 }
 
 func TestEngineApplyAndRevertReplayWorkspacePlacement(t *testing.T) {
-	p := 	newTestProfile()
+	p := newTestProfile()
 	p.Workspaces = profile.WorkspaceSettings{
 		Enabled:  true,
 		Strategy: profile.WorkspaceStrategyManual,
@@ -491,7 +491,7 @@ func TestEngineApplyAndRevertReplayWorkspacePlacement(t *testing.T) {
 }
 
 func TestEnginePostApply(t *testing.T) {
-	engine, _, err := initTestEngine(t)
+	engine, logPath, err := initTestEngine(t)
 	if err != nil {
 		t.Fatalf("init test engine: %v", err)
 	}
@@ -515,10 +515,12 @@ func TestEnginePostApply(t *testing.T) {
 	ctx := context.Background()
 
 	testcases := []struct {
+		ExecPath        string
 		Name            string
 		Mode            applyMode
 		OutFile         string
 		ShouldTouchFile bool
+		VerifyResult    func()
 	}{
 		{
 			Name:    "should_not_call_post_exec_when_interactive",
@@ -531,6 +533,31 @@ func TestEnginePostApply(t *testing.T) {
 			OutFile:         filepath.Join(dir, "b33b65c7-2c39-4df6-b56b-3ff64c816ff6"),
 			ShouldTouchFile: true,
 		},
+		{
+			Name:     "should_handle_space_only_exec",
+			ExecPath: "   ",
+			Mode:     ApplyModeNonInteractive,
+			OutFile:  filepath.Join(dir, "50000812-ca77-4f76-a1ed-7f7659c65fe3"),
+		},
+		{
+			Name: "should_continue_on_post_apply_fail",
+			Mode: ApplyModeNonInteractive,
+			VerifyResult: func() {
+				logBytes, err := os.ReadFile(logPath)
+				if err != nil {
+					t.Fatalf("read hyprctl log: %v", err)
+				}
+				log := string(logBytes)
+
+				want := "post apply:"
+
+				t.Log(log)
+
+				if !strings.Contains(log, want) {
+					t.Fatalf("Expected log to contain string \"%s\"", want)
+				}
+			},
+		},
 	}
 
 	p := newTestProfile()
@@ -538,7 +565,11 @@ func TestEnginePostApply(t *testing.T) {
 	for _, tc := range testcases {
 		t.Run(tc.Name, func(st *testing.T) {
 
-			p.Exec = fmt.Sprintf("%s %s", execPath, tc.OutFile)
+			if tc.ExecPath == "" {
+				p.Exec = fmt.Sprintf("%s %s", execPath, tc.OutFile)
+			} else {
+				p.Exec = tc.ExecPath
+			}
 
 			_, err := engine.Apply(ctx, p, monitors, tc.Mode)
 			if err != nil {
@@ -558,6 +589,10 @@ func TestEnginePostApply(t *testing.T) {
 
 			if fileExists != tc.ShouldTouchFile {
 				st.Fatalf("expected file to exist: %v. File exists: %v.", tc.ShouldTouchFile, fileExists)
+			}
+
+			if tc.VerifyResult != nil {
+				tc.VerifyResult()
 			}
 		})
 	}
@@ -649,11 +684,25 @@ exit 1
 			{Workspace: "2", OutputKey: monitors[1].HardwareKey(), OutputName: monitors[1].Name, Default: true, Persistent: true},
 		},
 	}
+	logf := func(format string, args ...any) {
+		msg := fmt.Sprintf(format, args...)
+		file, err := os.OpenFile(logPath, os.O_RDWR, 0o644)
+		if err != nil {
+			t.Fatalf("open log file: %v", err)
+		}
+		defer file.Close()
+
+		_, err = file.WriteString(msg)
+		if err != nil {
+			t.Fatalf("write to log file: %v", err)
+		}
+	}
 
 	engine = &Engine{
 		Client:             client,
 		MonitorsConfPath:   monitorsConfPath,
 		HyprlandConfigPath: hyprlandConfigPath,
+		Logf:               logf,
 	}
 
 	return

--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -45,6 +45,7 @@ func New(client *hypr.Client, store *profile.Store, cfg Config) *Service {
 			Client:             client,
 			MonitorsConfPath:   cfg.MonitorsConf,
 			HyprlandConfigPath: cfg.HyprConfig,
+			Logf:               cfg.Logf,
 		},
 		cfg: cfg,
 	}

--- a/internal/profile/types.go
+++ b/internal/profile/types.go
@@ -73,6 +73,7 @@ type Profile struct {
 	UpdatedAt  time.Time         `json:"updated_at"`
 	Outputs    []OutputConfig    `json:"outputs"`
 	Workspaces WorkspaceSettings `json:"workspaces,omitempty"`
+	Exec       string            `json:"exec"`
 }
 
 func New(name string, outputs []OutputConfig) Profile {

--- a/internal/tui/footer.go
+++ b/internal/tui/footer.go
@@ -41,7 +41,7 @@ func (m Model) footerHelpText() string {
 	case tabLayout:
 		return "`drag/arrows` move | `[ ]` cycle monitors | `Enter` edit | `Tab` pane | `a` apply | `s` save | `r` reset"
 	case tabProfiles:
-		return "`Enter` load | `a` apply | `d` delete | `s` save"
+		return "`Enter` load | `a` apply | `e` edit exec | `d` delete | `s` save"
 	case tabWorkspaces:
 		return "`↑↓` select | `←→` adjust or reorder | `a` apply | `s` save"
 	default:

--- a/internal/tui/interaction.go
+++ b/internal/tui/interaction.go
@@ -202,12 +202,23 @@ func (m Model) renderModalScreen(overlay string) string {
 
 	width := m.terminalWidth()
 	height := m.terminalHeight()
+	toast := m.renderToast()
+	toastHeight := 0
+	if toast != "" {
+		toastHeight = lipgloss.Height(toast) + 1
+	}
 
 	title := m.renderTitleBar()
 	tabs := m.renderTabs()
-	bodyHeight := max(12, height-lipgloss.Height(title)-lipgloss.Height(tabs)-2)
+	bodyHeight := max(12, height-lipgloss.Height(title)-lipgloss.Height(tabs)-2-toastHeight)
 	centered := lipgloss.Place(width-2, bodyHeight, lipgloss.Center, lipgloss.Center, overlay)
 	body := m.styles.modalBackdrop.Width(width).Height(bodyHeight).Render(centered)
+	if toast != "" {
+		body = strings.Join([]string{
+			body,
+			lipgloss.PlaceHorizontal(max(1, width-2), lipgloss.Center, toast),
+		}, "\n")
+	}
 	return strings.Join([]string{title, tabs, body}, "\n")
 }
 

--- a/internal/tui/interaction.go
+++ b/internal/tui/interaction.go
@@ -49,6 +49,13 @@ type numericInputState struct {
 	Input       textinput.Model
 }
 
+type profileExecInputState struct {
+	ProfileIndex int
+	Title        string
+	Hint         string
+	Input        textinput.Model
+}
+
 type profileListItem struct {
 	name    string
 	updated time.Time
@@ -470,6 +477,54 @@ func (m Model) renderNumericInput() string {
 	return m.renderModalFrame(m.input.Title, body)
 }
 
+func (m *Model) openProfileExecInput() tea.Cmd {
+	if len(m.profiles) == 0 || m.selectedProfile < 0 || m.selectedProfile >= len(m.profiles) {
+		return nil
+	}
+
+	selected := m.profiles[m.selectedProfile]
+	input := textinput.New()
+	input.Prompt = ""
+	input.CharLimit = 512
+	input.Width = clampInt(m.modalMaxWidth()-16, 24, 72)
+	input.TextStyle = m.styles.value
+	input.PlaceholderStyle = m.styles.subtle
+	input.Cursor.Style = lipgloss.NewStyle()
+	input.Placeholder = "/path/to/script.sh"
+	input.SetValue(selected.Exec)
+	cmd := input.Focus()
+
+	m.execInput = &profileExecInputState{
+		ProfileIndex: m.selectedProfile,
+		Title:        fmt.Sprintf("Edit Exec for %s", selected.Name),
+		Hint:         "Set the optional command to run after this profile is applied. Enter updates the profile in memory. Esc cancels.",
+		Input:        input,
+	}
+	m.mode = modeProfileExecInput
+	return cmd
+}
+
+func (m Model) renderProfileExecInput() string {
+	if m.execInput == nil {
+		return ""
+	}
+
+	inputBox := lipgloss.NewStyle().
+		Border(lipgloss.RoundedBorder()).
+		BorderForeground(lipgloss.Color(m.styles.palette.paneActiveBorder)).
+		Padding(0, 1).
+		Render(m.execInput.Input.View())
+	body := []string{
+		m.styles.subtle.MaxWidth(max(20, m.modalMaxWidth()-6)).Render(m.execInput.Hint),
+		"",
+		m.styles.label.Render("Exec"),
+		inputBox,
+		"",
+		m.styles.help.MaxWidth(max(20, m.modalMaxWidth()-6)).Render("Enter confirms the edit. Esc discards it. Press s on the Profiles tab to save the profile."),
+	}
+	return m.renderModalFrame(m.execInput.Title, body)
+}
+
 func (m *Model) openSaveDialog() (tea.Model, tea.Cmd) {
 	input := textinput.New()
 	input.Prompt = ""
@@ -689,6 +744,52 @@ func (m Model) updateSaveConfirmKeys(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 	default:
 		return m, nil
 	}
+}
+
+func (m *Model) updateProfileExecInputKeys(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
+	if m.execInput == nil {
+		m.mode = modeMain
+		return m, nil
+	}
+
+	switch msg.String() {
+	case "esc", "q":
+		m.execInput = nil
+		m.mode = modeMain
+		return m, nil
+	case "enter":
+		return m, m.commitProfileExecInput()
+	}
+
+	var cmd tea.Cmd
+	m.execInput.Input, cmd = m.execInput.Input.Update(msg)
+	return m, cmd
+}
+
+func (m *Model) commitProfileExecInput() tea.Cmd {
+	if m.execInput == nil {
+		m.mode = modeMain
+		return nil
+	}
+	if m.execInput.ProfileIndex < 0 || m.execInput.ProfileIndex >= len(m.profiles) {
+		m.execInput = nil
+		m.mode = modeMain
+		return nil
+	}
+
+	selected := &m.profiles[m.execInput.ProfileIndex]
+	selected.Exec = strings.TrimSpace(m.execInput.Input.Value())
+	if strings.EqualFold(strings.TrimSpace(m.draftProfileName), strings.TrimSpace(selected.Name)) {
+		m.draftExec = selected.Exec
+	}
+	if selected.Exec == "" {
+		m.setStatusOK(fmt.Sprintf("Cleared exec for %q. Press s to save.", selected.Name))
+	} else {
+		m.setStatusOK(fmt.Sprintf("Updated exec for %q. Press s to save.", selected.Name))
+	}
+	m.execInput = nil
+	m.mode = modeMain
+	return nil
 }
 
 func (m *Model) updateModePickerKeys(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
@@ -923,7 +1024,7 @@ func (m *Model) updateMouse(msg tea.MouseMsg) (tea.Model, tea.Cmd) {
 		return m.updateSaveMouse(msg)
 	case modeModePicker:
 		return m.updateModePickerMouse(msg)
-	case modeNumericInput, modeSaveConfirm, modeConfirm:
+	case modeNumericInput, modeProfileExecInput, modeSaveConfirm, modeConfirm:
 		return m, nil
 	}
 

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -81,6 +81,10 @@ type openURLMsg struct {
 	err   error
 }
 
+type clearToastMsg struct {
+	token int
+}
+
 type clearSnapMsg struct {
 	token int
 }
@@ -91,6 +95,12 @@ type pendingApply struct {
 	snapshot apply.RevertState
 	target   string
 	deadline time.Time
+}
+
+type toastState struct {
+	message string
+	err     bool
+	token   int
 }
 
 type editableOutput struct {
@@ -219,8 +229,10 @@ type Model struct {
 	input         *numericInputState
 	execInput     *profileExecInputState
 	drag          *canvasDragState
+	toast         *toastState
 	snap          *snapHintState
 	snapSeq       int
+	toastSeq      int
 
 	resetRequested   bool
 	status           string
@@ -344,6 +356,12 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	case clearSnapMsg:
 		if m.snap != nil && msg.token == m.snap.Token {
 			m.snap = nil
+		}
+		return m, nil
+
+	case clearToastMsg:
+		if m.toast != nil && msg.token == m.toast.token {
+			m.toast = nil
 		}
 		return m, nil
 
@@ -641,18 +659,22 @@ func (m Model) updateConfirmKeys(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 	case "ctrl+c", "q":
 		return m, tea.Quit
 	case "y", "enter":
+		var toastCmd tea.Cmd
 		if target := strings.TrimSpace(m.pending.target); target != "" && target != "draft" {
 			m.draftProfileName = target
 
 			if profile, exists := m.profileByName(target); exists {
-				m.postApply(profile)
+				if err := m.postApply(profile); err != nil {
+					toastCmd = m.notifyUser(fmt.Sprintf("Post-apply failed for %q: %v", profile.Name, err), true)
+				}
 			}
 		}
+
 		m.mode = modeMain
 		m.pending = nil
 		m.markClean()
 		m.setStatusOK("Configuration kept")
-		return m, m.refreshCmd()
+		return m, tea.Batch(m.refreshCmd(), toastCmd)
 	case "n", "esc":
 		snapshot := m.pending.snapshot
 		return m, m.revertCmd(snapshot, "user request")
@@ -683,9 +705,14 @@ func (m Model) View() string {
 func (m Model) renderMain() string {
 	title := m.renderTitleBar()
 	tabs := m.renderTabs()
+	toast := m.renderToast()
+	toastHeight := 0
+	if toast != "" {
+		toastHeight = lipgloss.Height(toast) + 1
+	}
 
 	footerText := m.renderFooterBar()
-	bodyHeight := m.mainBodyHeight(title, tabs, "", footerText)
+	bodyHeight := max(3, m.mainBodyHeight(title, tabs, "", footerText)-toastHeight)
 
 	var body string
 	switch m.tab {
@@ -703,6 +730,15 @@ func (m Model) renderMain() string {
 		title,
 		tabs,
 		body,
+	}, "\n")
+	if toast != "" {
+		content = strings.Join([]string{
+			content,
+			lipgloss.PlaceHorizontal(m.footerContentWidth(), lipgloss.Center, toast),
+		}, "\n")
+	}
+	content = strings.Join([]string{
+		content,
 		styledFooter,
 	}, "\n")
 	app := m.styles.app
@@ -1166,6 +1202,17 @@ func (m Model) renderConfirm() string {
 		m.styles.help.MaxWidth(max(20, m.modalMaxWidth()-6)).Render("Enter or y keeps the change. Esc or n reverts it."),
 	}
 	return m.renderModalFrame("Confirm Apply", body)
+}
+
+func (m Model) renderToast() string {
+	if m.toast == nil || strings.TrimSpace(m.toast.message) == "" {
+		return ""
+	}
+	style := m.styles.toast
+	if m.toast.err {
+		style = m.styles.toastError
+	}
+	return style.MaxWidth(max(24, m.terminalWidth()-8)).Render(m.toast.message)
 }
 
 func (m Model) renderStatus() string {
@@ -2038,6 +2085,21 @@ func (m *Model) setStatusOK(msg string) {
 	m.statusErr = false
 }
 
+func (m *Model) notifyUser(msg string, isErr bool) tea.Cmd {
+	msg = strings.TrimSpace(msg)
+	if msg == "" {
+		return nil
+	}
+	m.toastSeq++
+	token := m.toastSeq
+	m.toast = &toastState{
+		message: msg,
+		err:     isErr,
+		token:   token,
+	}
+	return clearToastCmd(token)
+}
+
 func isDaemonRunning() bool {
 	return exec.Command("pgrep", "-x", "hyprmoncfgd").Run() == nil
 }
@@ -2670,6 +2732,12 @@ func (m *Model) showSnapHint(hint *snapHintState) tea.Cmd {
 func clearSnapCmd(token int) tea.Cmd {
 	return tea.Tick(700*time.Millisecond, func(time.Time) tea.Msg {
 		return clearSnapMsg{token: token}
+	})
+}
+
+func clearToastCmd(token int) tea.Cmd {
+	return tea.Tick(4*time.Second, func(time.Time) tea.Msg {
+		return clearToastMsg{token: token}
 	})
 }
 

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -26,6 +26,7 @@ const (
 	modeConfirm
 	modeModePicker
 	modeNumericInput
+	modeProfileExecInput
 )
 
 type mainTab int
@@ -52,8 +53,9 @@ type refreshMsg struct {
 }
 
 type saveMsg struct {
-	name string
-	err  error
+	name       string
+	err        error
+	profileTab bool
 }
 
 type deleteMsg struct {
@@ -214,6 +216,7 @@ type Model struct {
 	saveOverwrite string
 	picker        *modePickerState
 	input         *numericInputState
+	execInput     *profileExecInputState
 	drag          *canvasDragState
 	snap          *snapHintState
 	snapSeq       int
@@ -224,6 +227,7 @@ type Model struct {
 	dirty            bool
 	draftSaved       bool
 	draftProfileName string
+	draftExec        string
 	daemonOK         bool
 
 	width  int
@@ -277,6 +281,9 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		if m.input != nil {
 			m.input.Input.Width = m.numericInputWidthFor(m.input.Kind)
 		}
+		if m.execInput != nil {
+			m.execInput.Input.Width = clampInt(m.modalMaxWidth()-16, 24, 72)
+		}
 		return m, nil
 
 	case refreshMsg:
@@ -303,6 +310,10 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			m.setStatusErr(msg.err.Error())
 			m.mode = modeMain
 			return m, nil
+		}
+		if msg.profileTab {
+			m.setStatusOK(fmt.Sprintf("Saved profile %q", msg.name))
+			return m, m.refreshCmd()
 		}
 		action := saveActionOnly
 		if m.saveDialog != nil {
@@ -339,6 +350,7 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		}
 		if strings.EqualFold(strings.TrimSpace(msg.name), strings.TrimSpace(m.draftProfileName)) {
 			m.draftProfileName = ""
+			m.draftExec = ""
 		}
 		m.setStatusOK(fmt.Sprintf("Deleted profile %q", msg.name))
 		m.selectedProfile = clampIndex(m.selectedProfile, len(m.profiles))
@@ -369,6 +381,7 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		}
 		m.markClean()
 		m.draftProfileName = ""
+		m.draftExec = ""
 		m.setStatusOK("Configuration reverted: " + msg.reason)
 		return m, m.refreshCmd()
 
@@ -400,6 +413,8 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			return m.updateModePickerKeys(msg)
 		case modeNumericInput:
 			return m.updateNumericInputKeys(msg)
+		case modeProfileExecInput:
+			return m.updateProfileExecInputKeys(msg)
 		default:
 			return m.updateMainKeys(msg)
 		}
@@ -420,6 +435,12 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		if m.input != nil {
 			var cmd tea.Cmd
 			m.input.Input, cmd = m.input.Input.Update(msg)
+			return m, cmd
+		}
+	case modeProfileExecInput:
+		if m.execInput != nil {
+			var cmd tea.Cmd
+			m.execInput.Input, cmd = m.execInput.Input.Update(msg)
 			return m, cmd
 		}
 	}
@@ -443,9 +464,17 @@ func (m Model) updateMainKeys(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 	case "r":
 		m.resetRequested = true
 		m.draftProfileName = ""
+		m.draftExec = ""
 		m.markClean()
 		return m, m.refreshCmd()
 	case "s":
+		if m.tab == tabProfiles {
+			if len(m.profiles) == 0 {
+				m.setStatusErr("No profiles to save")
+				return m, nil
+			}
+			return m, m.saveProfileCmd(m.profiles[m.selectedProfile])
+		}
 		return m.openSaveDialog()
 	case "a":
 		if m.tab == tabProfiles {
@@ -532,6 +561,12 @@ func (m Model) updateProfileKeys(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		m.selectedProfile = clampIndex(m.selectedProfile-1, len(m.profiles))
 	case "down", "j":
 		m.selectedProfile = clampIndex(m.selectedProfile+1, len(m.profiles))
+	case "e":
+		if len(m.profiles) == 0 {
+			m.setStatusErr("No profiles to edit")
+			return m, nil
+		}
+		return m, m.openProfileExecInput()
 	case "d":
 		if len(m.profiles) == 0 {
 			m.setStatusErr("No profiles to delete")
@@ -604,6 +639,7 @@ func (m Model) updateConfirmKeys(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 	case "y", "enter":
 		if target := strings.TrimSpace(m.pending.target); target != "" && target != "draft" {
 			m.draftProfileName = target
+			m.postApply(m.profiles[m.selectedProfile])
 		}
 		m.mode = modeMain
 		m.pending = nil
@@ -630,6 +666,8 @@ func (m Model) View() string {
 		return m.renderModalScreen(m.renderModePicker())
 	case modeNumericInput:
 		return m.renderModalScreen(m.renderNumericInput())
+	case modeProfileExecInput:
+		return m.renderModalScreen(m.renderProfileExecInput())
 	default:
 		return m.renderMain()
 	}
@@ -939,6 +977,14 @@ func (m Model) renderProfilesView(height int) string {
 			detailLines = append(detailLines, line)
 		}
 
+		execDisplay := selected.Exec
+		if execDisplay == "" {
+			execDisplay = "<not set>"
+		}
+
+		detailLines = append(detailLines, "")
+		detailLines = append(detailLines, fmt.Sprintf("Exec: %s", execDisplay))
+
 		preview := profile.WorkspacePreview(selected.Workspaces, selected.Outputs, m.monitors)
 		if len(preview) > 0 {
 			detailLines = append(detailLines, "")
@@ -1230,8 +1276,10 @@ func (m *Model) loadLiveState() {
 	m.workspaceEdit = workspaceEditorFromSettings(settings, m.editOutputs)
 	if matched, ok := profile.ExactStateMatch(m.profiles, m.monitors, m.workspaceRules); ok {
 		m.draftProfileName = matched.Name
+		m.draftExec = matched.Exec
 	} else {
 		m.draftProfileName = ""
+		m.draftExec = ""
 	}
 
 	// Preserve fields that hyprctl cannot accurately report, unless the
@@ -1305,6 +1353,7 @@ func (m *Model) loadProfile(p profile.Profile) {
 	m.dirty = true
 	m.draftSaved = true
 	m.draftProfileName = p.Name
+	m.draftExec = p.Exec
 	m.setStatusOK(fmt.Sprintf("Loaded profile %q into editor", p.Name))
 
 	m.revalidate()
@@ -1344,13 +1393,18 @@ func (m *Model) syncSelections() {
 }
 
 func (m Model) profileExists(name string) bool {
+	_, ok := m.profileByName(name)
+	return ok
+}
+
+func (m Model) profileByName(name string) (profile.Profile, bool) {
 	name = strings.TrimSpace(strings.ToLower(name))
 	for _, prof := range m.profiles {
 		if strings.TrimSpace(strings.ToLower(prof.Name)) == name {
-			return true
+			return prof, true
 		}
 	}
-	return false
+	return profile.Profile{}, false
 }
 
 func (m Model) hasMirroredOutputs() bool {
@@ -1687,8 +1741,19 @@ func (m *Model) moveWorkspaceOrder(delta int) {
 func (m Model) currentProfile(name string) profile.Profile {
 	p := profile.New(name, m.currentProfileOutputs())
 	p.Workspaces = m.workspaceEdit.settings()
+	p.Exec = m.currentProfileExec(name)
 	p.Normalize()
 	return p
+}
+
+func (m Model) currentProfileExec(name string) string {
+	if exec := strings.TrimSpace(m.draftExec); exec != "" {
+		return exec
+	}
+	if existing, ok := m.profileByName(name); ok {
+		return existing.Exec
+	}
+	return ""
 }
 
 func (m Model) currentProfileOutputs() []profile.OutputConfig {
@@ -1756,6 +1821,16 @@ func (m Model) saveCmd(p profile.Profile) tea.Cmd {
 	}
 }
 
+func (m Model) saveProfileCmd(p profile.Profile) tea.Cmd {
+	store := m.store
+	return func() tea.Msg {
+		if err := store.Save(p); err != nil {
+			return saveMsg{name: p.Name, err: err, profileTab: true}
+		}
+		return saveMsg{name: p.Name, profileTab: true}
+	}
+}
+
 func (m Model) deleteCmd(name string) tea.Cmd {
 	store := m.store
 	return func() tea.Msg {
@@ -1777,12 +1852,19 @@ func (m Model) applyCmd(p profile.Profile) tea.Cmd {
 		if err != nil {
 			return applyMsg{target: p.Name, err: err}
 		}
-		snapshot, err := engine.Apply(ctx, p, monitors)
+		snapshot, err := engine.Apply(ctx, p, monitors, apply.ApplyModeInteractive)
 		if err != nil {
 			return applyMsg{target: p.Name, err: err}
 		}
 		return applyMsg{target: p.Name, snapshot: snapshot}
 	}
+}
+
+func (m Model) postApply(p profile.Profile) error {
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	return m.engine.PostApply(ctx, p)
 }
 
 func (m Model) revertCmd(snapshot apply.RevertState, reason string) tea.Cmd {

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"math"
+	"os"
 	"os/exec"
 	"sort"
 	"strings"
@@ -246,7 +247,9 @@ func NewModel(client *hypr.Client, store *profile.Store, monitorsConfPath string
 			Client:             client,
 			MonitorsConfPath:   monitorsConfPath,
 			HyprlandConfigPath: hyprlandConfigPath,
-			Logf:               func(string, ...any) {},
+			Logf:               func(format string, args ...any) {
+				fmt.Fprintf(os.Stderr, format, args...)
+			},
 		},
 		openURL:     openExternalURL,
 		styles:      newStyles(),

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -246,6 +246,7 @@ func NewModel(client *hypr.Client, store *profile.Store, monitorsConfPath string
 			Client:             client,
 			MonitorsConfPath:   monitorsConfPath,
 			HyprlandConfigPath: hyprlandConfigPath,
+			Logf:               func(string, ...any) {},
 		},
 		openURL:     openExternalURL,
 		styles:      newStyles(),

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -640,7 +640,10 @@ func (m Model) updateConfirmKeys(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 	case "y", "enter":
 		if target := strings.TrimSpace(m.pending.target); target != "" && target != "draft" {
 			m.draftProfileName = target
-			m.postApply(m.profiles[m.selectedProfile])
+
+			if profile, exists := m.profileByName(target); exists {
+				m.postApply(profile)
+			}
 		}
 		m.mode = modeMain
 		m.pending = nil

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -65,7 +65,7 @@ type deleteMsg struct {
 }
 
 type applyMsg struct {
-	target   string
+	profile  profile.Profile
 	snapshot apply.RevertState
 	err      error
 }
@@ -92,8 +92,8 @@ type clearSnapMsg struct {
 type tickMsg time.Time
 
 type pendingApply struct {
+	profile  profile.Profile
 	snapshot apply.RevertState
-	target   string
 	deadline time.Time
 }
 
@@ -259,7 +259,7 @@ func NewModel(client *hypr.Client, store *profile.Store, monitorsConfPath string
 			Client:             client,
 			MonitorsConfPath:   monitorsConfPath,
 			HyprlandConfigPath: hyprlandConfigPath,
-			Logf:               func(format string, args ...any) {
+			Logf: func(format string, args ...any) {
 				fmt.Fprintf(os.Stderr, format, args...)
 			},
 		},
@@ -385,13 +385,13 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			return m, nil
 		}
 		m.pending = &pendingApply{
+			profile:  msg.profile,
 			snapshot: msg.snapshot,
-			target:   msg.target,
 			deadline: time.Now().Add(10 * time.Second),
 		}
 		m.mode = modeConfirm
 		m.statusErr = false
-		m.status = fmt.Sprintf("%s applied. Changes are live until you confirm or revert.", targetLabel(msg.target))
+		m.status = fmt.Sprintf("%s applied. Changes are live until you confirm or revert.", targetLabel(msg.profile.Name))
 		return m, tickCmd()
 
 	case revertMsg:
@@ -660,14 +660,14 @@ func (m Model) updateConfirmKeys(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		return m, tea.Quit
 	case "y", "enter":
 		var toastCmd tea.Cmd
-		if target := strings.TrimSpace(m.pending.target); target != "" && target != "draft" {
-			m.draftProfileName = target
 
-			if profile, exists := m.profileByName(target); exists {
-				if err := m.postApply(profile); err != nil {
-					toastCmd = m.notifyUser(fmt.Sprintf("Post-apply failed for %q: %v", profile.Name, err), true)
-				}
-			}
+		p := m.pending.profile
+		if target := strings.TrimSpace(p.Name); target != "" && target != "draft" {
+			m.draftProfileName = target
+		}
+
+		if err := m.postApply(p); err != nil {
+			toastCmd = m.notifyUser(fmt.Sprintf("Post-apply failed for %q: %v", p.Name, err), true)
 		}
 
 		m.mode = modeMain
@@ -1195,7 +1195,7 @@ func (m Model) renderConfirm() string {
 	}
 
 	body := []string{
-		m.styles.warning.Render(fmt.Sprintf("%s is live now.", targetLabel(m.pending.target))),
+		m.styles.warning.Render(fmt.Sprintf("%s is live now.", targetLabel(m.pending.profile.Name))),
 		m.styles.subtle.Render(fmt.Sprintf("Keep it within %ds or the previous state will be restored.", remaining)),
 		"",
 		m.renderStatus(),
@@ -1904,13 +1904,13 @@ func (m Model) applyCmd(p profile.Profile) tea.Cmd {
 
 		monitors, err := client.Monitors(ctx)
 		if err != nil {
-			return applyMsg{target: p.Name, err: err}
+			return applyMsg{profile: p, err: err}
 		}
 		snapshot, err := engine.Apply(ctx, p, monitors, apply.ApplyModeInteractive)
 		if err != nil {
-			return applyMsg{target: p.Name, err: err}
+			return applyMsg{profile: p, err: err}
 		}
-		return applyMsg{target: p.Name, snapshot: snapshot}
+		return applyMsg{profile: p, snapshot: snapshot}
 	}
 }
 

--- a/internal/tui/model_test.go
+++ b/internal/tui/model_test.go
@@ -88,6 +88,45 @@ func TestRenderMainShowsFooterProjectLinks(t *testing.T) {
 	}
 }
 
+func TestNotifyUserRendersToastInMainView(t *testing.T) {
+	m := Model{
+		styles:          newStyles(),
+		mode:            modeMain,
+		tab:             tabProfiles,
+		width:           120,
+		height:          30,
+		selectedProfile: 0,
+		profiles:        []profile.Profile{{Name: "Desk Dock"}},
+	}
+
+	cmd := m.notifyUser("Post-apply failed", true)
+	if cmd == nil {
+		t.Fatal("expected notifyUser to return a clear command")
+	}
+
+	view := ansi.Strip(m.View())
+	if !strings.Contains(view, "Post-apply failed") {
+		t.Fatalf("expected toast message in rendered view, got:\n%s", view)
+	}
+}
+
+func TestClearToastMsgRemovesToast(t *testing.T) {
+	m := Model{
+		styles: newStyles(),
+		toast: &toastState{
+			message: "Post-apply failed",
+			err:     true,
+			token:   3,
+		},
+	}
+
+	updated, _ := m.Update(clearToastMsg{token: 3})
+	got := updated.(Model)
+	if got.toast != nil {
+		t.Fatalf("expected toast to be cleared, got %+v", got.toast)
+	}
+}
+
 func TestRenderFooterInfoIncludesVersion(t *testing.T) {
 	prevVersion := buildinfo.Version
 	buildinfo.Version = "1.2.3"

--- a/internal/tui/model_test.go
+++ b/internal/tui/model_test.go
@@ -703,6 +703,114 @@ func TestLoadLiveStateInfersDraftProfileNameFromExactCurrentProfile(t *testing.T
 	}
 }
 
+func TestProfileExecEditorOpensWithCurrentValue(t *testing.T) {
+	m := Model{
+		styles:   newStyles(),
+		tab:      tabProfiles,
+		profiles: []profile.Profile{{Name: "Desk Dock", Exec: "/path/to/script.sh"}},
+	}
+
+	updatedModel, cmd := m.updateProfileKeys(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'e'}})
+	got := updatedModel.(Model)
+
+	if cmd == nil {
+		t.Fatal("expected exec editor to focus its input")
+	}
+	if got.mode != modeProfileExecInput {
+		t.Fatalf("expected exec editor mode, got %v", got.mode)
+	}
+	if got.execInput == nil {
+		t.Fatal("expected exec input state to be initialized")
+	}
+	if got.execInput.Input.Value() != "/path/to/script.sh" {
+		t.Fatalf("expected exec editor to prefill current value, got %q", got.execInput.Input.Value())
+	}
+}
+
+func TestProfileExecEditorEnterUpdatesSelectedProfileInMemory(t *testing.T) {
+	m := Model{
+		styles:   newStyles(),
+		tab:      tabProfiles,
+		profiles: []profile.Profile{{Name: "Desk Dock"}},
+	}
+
+	updatedModel, _ := m.updateProfileKeys(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'e'}})
+	got := updatedModel.(Model)
+	got.execInput.Input.SetValue("/path/to/script.sh")
+
+	nextModel, _ := got.updateProfileExecInputKeys(tea.KeyMsg{Type: tea.KeyEnter})
+	next := nextModel.(*Model)
+
+	if next.mode != modeMain {
+		t.Fatalf("expected exec editor to close after Enter, got %v", next.mode)
+	}
+	if next.execInput != nil {
+		t.Fatalf("expected exec input to be cleared, got %+v", next.execInput)
+	}
+	if next.profiles[0].Exec != "/path/to/script.sh" {
+		t.Fatalf("expected exec to update in memory, got %q", next.profiles[0].Exec)
+	}
+	if !strings.Contains(next.status, "Press s to save") {
+		t.Fatalf("expected status to mention explicit save, got %q", next.status)
+	}
+}
+
+func TestProfileExecEditorEscDiscardsChange(t *testing.T) {
+	m := Model{
+		styles:   newStyles(),
+		tab:      tabProfiles,
+		profiles: []profile.Profile{{Name: "Desk Dock", Exec: "/path/to/script.sh"}},
+	}
+
+	updatedModel, _ := m.updateProfileKeys(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'e'}})
+	got := updatedModel.(Model)
+	got.execInput.Input.SetValue("/other/script.sh")
+
+	nextModel, _ := got.updateProfileExecInputKeys(tea.KeyMsg{Type: tea.KeyEsc})
+	next := nextModel.(*Model)
+
+	if next.profiles[0].Exec != "/path/to/script.sh" {
+		t.Fatalf("expected Esc to discard changes, got %q", next.profiles[0].Exec)
+	}
+	if next.mode != modeMain {
+		t.Fatalf("expected exec editor to close on Esc, got %v", next.mode)
+	}
+}
+
+func TestProfilesTabSavePersistsSelectedProfileExec(t *testing.T) {
+	store := profile.NewStore(t.TempDir())
+	savedProfile := testProfile("Desk Dock", 1)
+	savedProfile.Exec = "/path/to/script.sh"
+	m := Model{
+		styles:           newStyles(),
+		tab:              tabProfiles,
+		store:            store,
+		profiles:         []profile.Profile{savedProfile},
+		draftProfileName: "Draft Name",
+	}
+
+	updatedModel, cmd := m.updateMainKeys(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'s'}})
+	got := updatedModel.(Model)
+	if cmd == nil {
+		t.Fatal("expected Profiles-tab save to return a command")
+	}
+
+	msg := cmd()
+	finalModel, _ := got.Update(msg)
+	final := finalModel.(Model)
+
+	saved, err := store.Load("Desk Dock")
+	if err != nil {
+		t.Fatalf("expected selected profile to be saved: %v", err)
+	}
+	if saved.Exec != savedProfile.Exec {
+		t.Fatalf("expected saved exec %q, got %q", savedProfile.Exec, saved.Exec)
+	}
+	if final.draftProfileName != "Draft Name" {
+		t.Fatalf("expected Profiles-tab save not to rewrite draft name, got %q", final.draftProfileName)
+	}
+}
+
 func TestSaveDialogMouseSelectsVisibleProfile(t *testing.T) {
 	m := Model{
 		styles:   newStyles(),

--- a/internal/tui/styles.go
+++ b/internal/tui/styles.go
@@ -108,6 +108,8 @@ type styles struct {
 	tabInactive      lipgloss.Style
 	statusOK         lipgloss.Style
 	statusError      lipgloss.Style
+	toast            lipgloss.Style
+	toastError       lipgloss.Style
 	help             lipgloss.Style
 	selectedDesc     lipgloss.Style
 	footerLinkWarm   lipgloss.Style
@@ -147,6 +149,8 @@ func newStyles() styles {
 		tabInactive:      withFG(lipgloss.NewStyle().Border(inactiveTabBorder).BorderForeground(lipgloss.Color(p.tabBorder)).Padding(0, 1), p.tabInactiveFg),
 		statusOK:         withFG(lipgloss.NewStyle().Bold(true), p.statusOK),
 		statusError:      withFG(lipgloss.NewStyle().Bold(true), p.statusError),
+		toast:            withBG(withFG(lipgloss.NewStyle().Border(lipgloss.RoundedBorder()).BorderForeground(lipgloss.Color(p.paneActiveBorder)).Padding(0, 2).Bold(true), p.badgeOnFg), p.badgeOnBg),
+		toastError:       withBG(withFG(lipgloss.NewStyle().Border(lipgloss.RoundedBorder()).BorderForeground(lipgloss.Color("15")).Padding(0, 2).Bold(true), "0"), "9"),
 		help:             withFG(lipgloss.NewStyle(), p.help),
 		selectedDesc:     withBG(withFG(lipgloss.NewStyle(), p.selectedDesc), p.fieldSelectedBg),
 		footerLinkWarm:   withFG(lipgloss.NewStyle().Underline(true), p.footerWarm),


### PR DESCRIPTION
Adds a new field `Exec` on the profile struct. This field is optional and can be edited by hitting `e` when a profile is focused on the profile tab. Hitting enter will commit the value to memory and hitting `s` after will save to profile to file. This means that the save function on the profile page have changed a little bit as well.

All three ways of applying a profile (daemon, CLI and TUI) call the same `Apply` method from the engine. Due to the way it works when applying from the TUI I decided to add an optional flag to the `Apply` method that sets the mode. On non-interactive modes the `PostApply` method will be run immediately at the end. On interactive mode `PostApply` will not be run until user confirms their changes.

Added a new dependency `github.com/buildkite/shellwords` which ensures proper parsing of the exec field to command + args. I didn't want to try handle the parsing myself since there are a couple of things to keep in mind when doing that (simply splitting on space would no be a very solid approach).

I did refactor the tests a bit so I could reuse some of the test setup that was already there. It may have inflates the number of changes on this commit a bit.

Let me know what you think, and if I should update the docs or make any other changes as well.

This implements #5 