### PR TITLE
Fix Omarchy Lua package.path include detection

### DIFF
--- a/internal/config/hyprland_lua.go
+++ b/internal/config/hyprland_lua.go
@@ -158,23 +158,37 @@ func parseLuaPackagePathPatterns(content string) []string {
 	patterns := make([]string, 0)
 	scanner := bufio.NewScanner(strings.NewReader(content))
 	inPackagePath := false
+	pendingPackagePathContinuation := false
 	activePackagePathEnv := ""
 	longCommentClose := ""
 	for scanner.Scan() {
 		line := strings.TrimSpace(stripLuaCommentsState(scanner.Text(), &longCommentClose))
 		if line == "" {
 			inPackagePath = false
+			pendingPackagePathContinuation = false
 			activePackagePathEnv = ""
 			continue
 		}
+
+		assignmentLine := false
+		leadingConcatLine := strings.HasPrefix(line, "..")
 		if rhs, ok := parseLuaPackagePathAssignmentRHS(line); ok {
+			assignmentLine = true
 			inPackagePath = true
+			pendingPackagePathContinuation = true
 			activePackagePathEnv = ""
 			line = rhs
-		}
-		if !inPackagePath {
+		} else if pendingPackagePathContinuation && leadingConcatLine {
+			inPackagePath = true
+		} else if !inPackagePath {
+			continue
+		} else if !leadingConcatLine && pendingPackagePathContinuation {
+			inPackagePath = false
+			pendingPackagePathContinuation = false
+			activePackagePathEnv = ""
 			continue
 		}
+
 		if envName, ok := parseLuaGetenvName(line); ok {
 			activePackagePathEnv = envName
 		}
@@ -185,7 +199,9 @@ func parseLuaPackagePathPatterns(content string) []string {
 			patterns = append(patterns, expandLuaPackagePathLiteral(literal)...)
 			patterns = append(patterns, expandLuaPackagePathEnvLiteral(literal, activePackagePathEnv)...)
 		}
-		if !isLuaPackagePathContinuation(line) {
+
+		pendingPackagePathContinuation = assignmentLine || leadingConcatLine || isLuaPackagePathContinuation(line)
+		if !pendingPackagePathContinuation {
 			inPackagePath = false
 			activePackagePathEnv = ""
 		}

--- a/internal/config/hyprland_test.go
+++ b/internal/config/hyprland_test.go
@@ -400,6 +400,34 @@ require('hypr.monitors')
 	}
 }
 
+func TestVerifyLuaSourceChainFindsOmarchyPackagePathRequire(t *testing.T) {
+	root := t.TempDir()
+	home := filepath.Join(root, "home")
+	hypr := filepath.Join(home, ".config", "hypr")
+	if err := os.MkdirAll(hypr, 0o755); err != nil {
+		t.Fatalf("mkdir hypr dir: %v", err)
+	}
+	rootConfig := filepath.Join(hypr, "hyprland.lua")
+	target := filepath.Join(hypr, "monitors.lua")
+
+	t.Setenv("HOME", home)
+	content := `package.path = os.getenv("HOME")
+  .. "/.config/?.lua;"
+  .. package.path
+require("hypr.monitors")
+`
+	if err := os.WriteFile(rootConfig, []byte(content), 0o644); err != nil {
+		t.Fatalf("write root config: %v", err)
+	}
+	if err := os.WriteFile(target, []byte("-- generated\n"), 0o644); err != nil {
+		t.Fatalf("write target config: %v", err)
+	}
+
+	if err := VerifyIncludeChain(HyprConfigLua, rootConfig, target); err != nil {
+		t.Fatalf("expected Omarchy package.path style lua include to verify, got %v", err)
+	}
+}
+
 func TestVerifyLuaSourceChainFindsPackagePathAssignmentForms(t *testing.T) {
 	tests := []struct {
 		name    string


### PR DESCRIPTION
## Summary

Fixes #24.

Omarchy Lua configs build `package.path` like this:

```lua
package.path = os.getenv("HOME")
  .. "/.config/?.lua;"
  .. package.path
require("hypr.monitors")
```

The include verifier previously stopped parsing the package path after the assignment line unless that line ended with `..`, so it missed `~/.config/?.lua` and falsely rejected `require("hypr.monitors")`.

This change keeps package-path parsing active for continuation lines that begin with `..`, including when concatenation starts on the line after the assignment.

## Test

- `mise exec go@1.24.2 -- go test ./...`