### PR TITLE
Add nix Flake

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,60 @@
+{
+  "nodes": {
+    "flake-utils": {
+      "inputs": {
+        "systems": "systems"
+      },
+      "locked": {
+        "lastModified": 1731533236,
+        "narHash": "sha256-l0KFg5HjrsfsO/JpG+r7fRrqm12kzFHyUHqHCVpMMbI=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "11707dc2f618dd54ca8739b309ec4fc024de578b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1780925302,
+        "narHash": "sha256-4ISpSCVglFoTJMVSjJzEHgMIU9ltyT4Vn5RQ0Qmq97k=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "5b0f84aa7349e94bd4f846dc4fb3606abfeaf45a",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "flake-utils": "flake-utils",
+        "nixpkgs": "nixpkgs"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -14,16 +14,17 @@
     flake-utils.lib.eachDefaultSystem (
       system: let
         pkgs = import nixpkgs {inherit system;};
+        version = "1.7.0";
       in {
         packages = rec {
           default = hyprmoncfg;
           hyprmoncfg = pkgs.buildGoModule {
             pname = "hyprmoncfg";
-            version = "v1.7.0";
+            version = "v${version}";
             src = pkgs.fetchFromGitHub {
               owner = "crmne";
               repo = "hyprmoncfg";
-              rev = "v1.7.0";
+              rev = "v${version}";
               hash = "sha256-6qupQ7/Uax6giaWC9o25EptyJNx6JdqrQX+w4WDBPTw=";
             };
 

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,83 @@
+{
+  description = "Hyprland monitor configuration that actually works";
+
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs";
+    flake-utils.url = "github:numtide/flake-utils";
+  };
+
+  outputs = {
+    self,
+    nixpkgs,
+    flake-utils,
+  }:
+    flake-utils.lib.eachDefaultSystem (
+      system: let
+        pkgs = import nixpkgs {inherit system;};
+      in {
+        packages = rec {
+          default = hyprmoncfg;
+          hyprmoncfg = pkgs.buildGoModule {
+            pname = "hyprmoncfg";
+            version = "v1.7.0";
+            src = pkgs.fetchFromGitHub {
+              owner = "crmne";
+              repo = "hyprmoncfg";
+              rev = "v1.7.0";
+              hash = "sha256-6qupQ7/Uax6giaWC9o25EptyJNx6JdqrQX+w4WDBPTw=";
+            };
+
+            subpackages = ["cmd/hyprmoncfg" "cmd/hyprmoncfgd"];
+            proxyVendor = true;
+            vendorHash = "sha256-97z4+U/SumG5sidy62SW43E+Bi6FpvJKCI6wqwXts2g=";
+            doCheck = false;
+
+            postInstall = ''
+              mkdir -p $out/share/applications
+              cp $src/packaging/applications/hyprmoncfg.desktop $out/share/applications/
+
+              mkdir -p $out/share/icons/hicolor/scalable/apps
+              cp $src/packaging/icons/hyprmoncfg.svg $out/share/icons/hicolor/scalable/apps/
+            '';
+          };
+        };
+      }
+    )
+    // {
+      nixosModules.default = {
+        config,
+        lib,
+        pkgs,
+        ...
+      }: let
+        cfg = config.programs.hyprmoncfg;
+      in {
+        options.programs.hyprmoncfg = {
+          enable = lib.mkEnableOption "hyprmoncfg, a Hyprland monitor configuration daemon";
+          package = lib.mkOption {
+            type = lib.types.package;
+            default = self.packages.${pkgs.system}.hyprmoncfg;
+            defaultText = lib.literalExpression "inputs.hyprmoncfg.packages.\${pkgs.system}.hyprmoncfg";
+            description = "The hyprmoncfg package to use.";
+          };
+        };
+
+        config = lib.mkIf cfg.enable {
+          environment.systemPackages = [cfg.package];
+
+          systemd.user.services.hyprmoncfgd = {
+            description = "Hyprland monitor profile daemon (hyprmoncfgd)";
+            after = ["graphical-session.target"];
+            wantedBy = ["default.target"];
+            path = [pkgs.hyprland];
+            serviceConfig = {
+              Type = "simple";
+              ExecStart = "${cfg.package}/bin/hyprmoncfgd";
+              Restart = "on-failure";
+              RestartSec = "2";
+            };
+          };
+        };
+      };
+    };
+}


### PR DESCRIPTION
This PR adds support for the inclusion of hyprmoncfg as a flake for nixos users.
By setting
```
programs.hyprmoncfg.enable = true;
```

`hyprmoncfg` will be added to the path. Furthermore, by setting this, it will also start and enable a systemd user service which runs `hyprmoncfgd`