### PR TITLE
fix: scan /proc manually and look for matching cmdline instead of pgrep

### DIFF
--- a/internal/tui/daemon_status_linux.go
+++ b/internal/tui/daemon_status_linux.go
@@ -1,0 +1,43 @@
+package tui
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"strconv"
+)
+
+const procRoot = "/proc"
+
+func isDaemonRunning() bool {
+	return daemonRunningIn(procRoot)
+}
+
+func daemonRunningIn(root string) bool {
+	entries, err := os.ReadDir(root)
+	if err != nil {
+		return false
+	}
+
+	for _, entry := range entries {
+		if !entry.IsDir() {
+			continue
+		}
+		if _, err := strconv.Atoi(entry.Name()); err != nil {
+			continue
+		}
+
+		cmdline, err := os.ReadFile(filepath.Join(root, entry.Name(), "cmdline"))
+		if err == nil && isDaemonCommand(cmdline) {
+			return true
+		}
+	}
+
+	return false
+}
+
+func isDaemonCommand(cmdline []byte) bool {
+	// Wrappers can change the kernel process name while preserving argv[0].
+	argv0, _, _ := bytes.Cut(cmdline, []byte{0})
+	return filepath.Base(string(argv0)) == "hyprmoncfgd"
+}

--- a/internal/tui/daemon_status_linux_test.go
+++ b/internal/tui/daemon_status_linux_test.go
@@ -1,0 +1,83 @@
+package tui
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestIsDaemonCommand(t *testing.T) {
+	tests := []struct {
+		name    string
+		cmdline string
+		want    bool
+	}{
+		{
+			name:    "bare executable",
+			cmdline: "hyprmoncfgd\x00--quiet\x00",
+			want:    true,
+		},
+		{
+			name:    "installed executable",
+			cmdline: "/usr/bin/hyprmoncfgd\x00",
+			want:    true,
+		},
+		{
+			name:    "Nix wrapper argv zero",
+			cmdline: "/nix/store/hash-hyprmoncfg/bin/hyprmoncfgd\x00",
+			want:    true,
+		},
+		{
+			name:    "Nix wrapped executable name",
+			cmdline: "/nix/store/hash-hyprmoncfg/bin/.hyprmoncfgd-wrapped\x00",
+			want:    false,
+		},
+		{
+			name:    "layout editor",
+			cmdline: "/usr/bin/hyprmoncfg\x00",
+			want:    false,
+		},
+		{
+			name: "empty command line",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			if got := isDaemonCommand([]byte(test.cmdline)); got != test.want {
+				t.Fatalf("isDaemonCommand(%q) = %v, want %v", test.cmdline, got, test.want)
+			}
+		})
+	}
+}
+
+func TestDaemonRunningIn(t *testing.T) {
+	root := t.TempDir()
+	writeCmdline(t, root, "100", "/usr/bin/hyprmoncfg\x00")
+	writeCmdline(t, root, "101", "/nix/store/hash-hyprmoncfg/bin/hyprmoncfgd\x00")
+
+	if !daemonRunningIn(root) {
+		t.Fatal("expected to find the daemon by argv[0]")
+	}
+}
+
+func TestDaemonRunningInReturnsFalseWithoutDaemon(t *testing.T) {
+	root := t.TempDir()
+	writeCmdline(t, root, "100", "/usr/bin/hyprmoncfg\x00")
+
+	if daemonRunningIn(root) {
+		t.Fatal("did not expect to find a daemon")
+	}
+}
+
+func writeCmdline(t *testing.T, root, pid, cmdline string) {
+	t.Helper()
+
+	processDir := filepath.Join(root, pid)
+	if err := os.Mkdir(processDir, 0o755); err != nil {
+		t.Fatalf("create process directory: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(processDir, "cmdline"), []byte(cmdline), 0o644); err != nil {
+		t.Fatalf("write command line: %v", err)
+	}
+}

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"math"
 	"os"
-	"os/exec"
 	"path/filepath"
 	"sort"
 	"strings"
@@ -2369,10 +2368,6 @@ func (m *Model) notifyUser(msg string, isErr bool) tea.Cmd {
 		token:   token,
 	}
 	return clearToastCmd(token)
-}
-
-func isDaemonRunning() bool {
-	return exec.Command("pgrep", "-x", "hyprmoncfgd").Run() == nil
 }
 
 func (m *Model) markDirty() {


### PR DESCRIPTION
Currently `pgrep` approach requires process name for daemon to be exactly `hyprmoncfgd`. This is not the case for some system where OS wraps some process adding suffixes to the process name. So, we could check for the process in `/proc` instead.

Also it is best not to spawn new process for each time we want to check if daemon is fine or not.

Addresses: https://github.com/crmne/hyprmoncfg/issues/34

AI disclosure: pi-agent with GPT-5.6 Sol was utilized to write the code. PR and issue is written by me.