### PR TITLE
fix(lua): only suggest a require() that can actually resolve

### DIFF
--- a/internal/config/hyprland_lua.go
+++ b/internal/config/hyprland_lua.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"slices"
 	"strings"
 )
 
@@ -19,9 +20,21 @@ func VerifyLuaIncludeChain(rootConfigPath string, targetPath string) error {
 		return err
 	}
 
-	ok, err := isLuaPathIncluded(rootConfigPath, targetPath, map[string]bool{})
+	state := &luaScanState{visited: map[string]bool{}}
+	ok, err := isLuaPathIncluded(rootConfigPath, targetPath, state)
 	if err != nil {
 		return err
+	}
+	// package.path can be assigned in a file that is loaded after the require()
+	// depending on it, or in a bootstrap file pulled in by the root config. Retry
+	// once seeded with everything the first pass learned so that the order the
+	// assignments appear in does not decide the outcome.
+	if !ok && len(state.patterns) > 0 {
+		retry := &luaScanState{visited: map[string]bool{}, patterns: state.patterns}
+		ok, err = isLuaPathIncluded(rootConfigPath, targetPath, retry)
+		if err != nil {
+			return err
+		}
 	}
 	if ok {
 		return nil
@@ -48,16 +61,32 @@ func quoteLuaArg(value string) string {
 	return fmt.Sprintf("%q", value)
 }
 
-func isLuaPathIncluded(rootConfigPath string, targetPath string, visited map[string]bool) (bool, error) {
+// luaScanState carries what the traversal has learned so far. package.path is
+// process-global in Lua, so a pattern assigned in one file applies to require()
+// calls in every other file the config loads, not just its own.
+type luaScanState struct {
+	visited  map[string]bool
+	patterns []string
+}
+
+func (s *luaScanState) addPatterns(patterns []string) {
+	for _, pattern := range patterns {
+		if !slices.Contains(s.patterns, pattern) {
+			s.patterns = append(s.patterns, pattern)
+		}
+	}
+}
+
+func isLuaPathIncluded(rootConfigPath string, targetPath string, state *luaScanState) (bool, error) {
 	rootConfigPath = filepath.Clean(rootConfigPath)
 	targetPath = filepath.Clean(targetPath)
 	if rootConfigPath == targetPath {
 		return true, nil
 	}
-	if visited[rootConfigPath] {
+	if state.visited[rootConfigPath] {
 		return false, nil
 	}
-	visited[rootConfigPath] = true
+	state.visited[rootConfigPath] = true
 
 	content, err := os.ReadFile(rootConfigPath)
 	if err != nil {
@@ -68,8 +97,9 @@ func isLuaPathIncluded(rootConfigPath string, targetPath string, visited map[str
 	}
 
 	contentString := string(content)
+	state.addPatterns(parseLuaPackagePathPatterns(contentString))
 	for _, include := range parseLuaIncludeCalls(contentString) {
-		includePaths, err := resolveLuaIncludePaths(include, filepath.Dir(rootConfigPath), contentString)
+		includePaths, err := resolveLuaIncludePaths(include, filepath.Dir(rootConfigPath), contentString, state.patterns)
 		if err != nil {
 			return false, err
 		}
@@ -87,7 +117,7 @@ func isLuaPathIncluded(rootConfigPath string, targetPath string, visited map[str
 			if info.IsDir() {
 				continue
 			}
-			ok, err := isLuaPathIncluded(includePath, targetPath, visited)
+			ok, err := isLuaPathIncluded(includePath, targetPath, state)
 			if err != nil {
 				return false, err
 			}
@@ -104,6 +134,10 @@ type luaIncludeKind int
 const (
 	luaIncludeRequire luaIncludeKind = iota
 	luaIncludeDofile
+	// luaIncludeDofileExpr is a dofile() whose argument is a concatenation
+	// rather than a plain literal, e.g.
+	//   dofile((os.getenv("BASE") or "/usr/share/x") .. "/bootstrap.lua")
+	luaIncludeDofileExpr
 )
 
 type luaIncludeCall struct {
@@ -111,7 +145,7 @@ type luaIncludeCall struct {
 	Value string
 }
 
-func resolveLuaIncludePaths(include luaIncludeCall, baseDir string, content string) ([]string, error) {
+func resolveLuaIncludePaths(include luaIncludeCall, baseDir string, content string, extraPatterns []string) ([]string, error) {
 	if include.Kind == luaIncludeDofile {
 		resolved, err := resolvePath(include.Value, baseDir)
 		if err != nil {
@@ -120,10 +154,23 @@ func resolveLuaIncludePaths(include luaIncludeCall, baseDir string, content stri
 		return []string{resolved}, nil
 	}
 
+	if include.Kind == luaIncludeDofileExpr {
+		out := make([]string, 0, 2)
+		for _, candidate := range evalLuaStringExpression(include.Value) {
+			resolved, err := resolvePath(candidate, baseDir)
+			if err != nil {
+				continue
+			}
+			out = append(out, resolved)
+		}
+		return out, nil
+	}
+
 	modulePath := luaModulePath(include.Value)
 	candidates := []string{filepath.Join(baseDir, modulePath)}
 	moduleName := strings.TrimSuffix(modulePath, ".lua")
-	for _, pattern := range parseLuaPackagePathPatterns(content) {
+	patterns := append(parseLuaPackagePathPatterns(content), extraPatterns...)
+	for _, pattern := range patterns {
 		if strings.Contains(pattern, "?") {
 			candidates = append(candidates, strings.ReplaceAll(pattern, "?", moduleName))
 		}
@@ -348,6 +395,9 @@ func parseLuaIncludeCalls(content string) []luaIncludeCall {
 		}
 		for _, value := range parseLuaLiteralCall(line, "dofile") {
 			out = append(out, luaIncludeCall{Kind: luaIncludeDofile, Value: value})
+		}
+		for _, expr := range parseLuaExpressionCallArgs(line, "dofile") {
+			out = append(out, luaIncludeCall{Kind: luaIncludeDofileExpr, Value: expr})
 		}
 	}
 	return out
@@ -586,4 +636,215 @@ func isLuaIdentifierByte(b byte) bool {
 
 func isParentRelativePath(value string) bool {
 	return value == ".." || strings.HasPrefix(value, ".."+string(os.PathSeparator))
+}
+
+// luaExprMaxCandidates bounds the fan-out from `or` branches so a pathological
+// expression cannot blow up the candidate list.
+const luaExprMaxCandidates = 16
+
+// parseLuaExpressionCallArgs returns the raw argument text of every call to name
+// on the line whose argument is not a plain string literal. Literal arguments are
+// left to parseLuaLiteralCall, which already handles them (including the
+// parenthesis-free `dofile "path"` form).
+func parseLuaExpressionCallArgs(line string, name string) []string {
+	out := make([]string, 0, 1)
+	for i := 0; i < len(line); i++ {
+		if line[i] == '\'' || line[i] == '"' {
+			if next, ok := skipLuaShortString(line, i); ok {
+				i = next - 1
+				continue
+			}
+		}
+		if i+1 < len(line) && line[i] == '-' && line[i+1] == '-' {
+			return out
+		}
+		if !isLuaNameAt(line, i, name) {
+			continue
+		}
+		open := trimLuaSpaceLeft(line, i+len(name))
+		if open >= len(line) || line[open] != '(' {
+			continue
+		}
+		closeIdx, ok := luaMatchingParen(line, open)
+		if !ok {
+			continue
+		}
+		arg := strings.TrimSpace(line[open+1 : closeIdx])
+		i = closeIdx
+		if arg == "" {
+			continue
+		}
+		if _, isLiteral := parseLuaSingleStringLiteral(arg); isLiteral {
+			continue
+		}
+		out = append(out, arg)
+	}
+	return out
+}
+
+// evalLuaStringExpression evaluates the small subset of Lua that configs use to
+// build a path: string literals, os.getenv("NAME"), parentheses, concatenation
+// and `or` fallbacks. Each `or` branch becomes its own candidate so the caller
+// can stat every one. Anything outside that subset yields no candidates, so an
+// unsupported expression is skipped rather than guessed at.
+func evalLuaStringExpression(expr string) []string {
+	expr = strings.TrimSpace(expr)
+	if expr == "" {
+		return nil
+	}
+
+	if branches := splitLuaTopLevel(expr, "or"); len(branches) > 1 {
+		out := make([]string, 0, len(branches))
+		for _, branch := range branches {
+			out = append(out, evalLuaStringExpression(branch)...)
+			if len(out) >= luaExprMaxCandidates {
+				return out[:luaExprMaxCandidates]
+			}
+		}
+		return out
+	}
+
+	if parts := splitLuaTopLevel(expr, ".."); len(parts) > 1 {
+		combos := []string{""}
+		for _, part := range parts {
+			values := evalLuaStringExpression(part)
+			if len(values) == 0 {
+				return nil
+			}
+			next := make([]string, 0, len(combos)*len(values))
+			for _, prefix := range combos {
+				for _, value := range values {
+					if len(next) >= luaExprMaxCandidates {
+						break
+					}
+					next = append(next, prefix+value)
+				}
+			}
+			combos = next
+		}
+		return combos
+	}
+
+	if inner, ok := luaBalancedInner(expr); ok {
+		return evalLuaStringExpression(inner)
+	}
+
+	if literal, ok := parseLuaSingleStringLiteral(expr); ok {
+		return []string{literal}
+	}
+
+	if strings.HasPrefix(expr, "os.getenv") {
+		if name, ok := parseLuaGetenvName(expr); ok {
+			if value := strings.TrimSpace(os.Getenv(name)); value != "" {
+				return []string{value}
+			}
+		}
+	}
+
+	return nil
+}
+
+// splitLuaTopLevel splits expr on sep, ignoring separators inside string
+// literals or bracketed groups. When sep is a word (like "or") it only matches
+// on identifier boundaries, so "for" is not mistaken for a fallback.
+func splitLuaTopLevel(expr string, sep string) []string {
+	parts := make([]string, 0, 2)
+	depth := 0
+	start := 0
+	wordSep := isLuaIdentifierByte(sep[0])
+	for i := 0; i < len(expr); i++ {
+		c := expr[i]
+		if c == '\'' || c == '"' {
+			if next, ok := skipLuaShortString(expr, i); ok {
+				i = next - 1
+				continue
+			}
+		}
+		switch c {
+		case '(', '[', '{':
+			depth++
+			continue
+		case ')', ']', '}':
+			depth--
+			continue
+		}
+		if depth != 0 || !strings.HasPrefix(expr[i:], sep) {
+			continue
+		}
+		if wordSep {
+			if i > 0 && isLuaIdentifierByte(expr[i-1]) {
+				continue
+			}
+			if i+len(sep) < len(expr) && isLuaIdentifierByte(expr[i+len(sep)]) {
+				continue
+			}
+		}
+		parts = append(parts, expr[start:i])
+		start = i + len(sep)
+		i += len(sep) - 1
+	}
+	if len(parts) == 0 {
+		return []string{expr}
+	}
+	return append(parts, expr[start:])
+}
+
+// luaBalancedInner unwraps expr when it is a single parenthesised group.
+func luaBalancedInner(expr string) (string, bool) {
+	if expr == "" || expr[0] != '(' {
+		return "", false
+	}
+	closeIdx, ok := luaMatchingParen(expr, 0)
+	if !ok || closeIdx != len(expr)-1 {
+		return "", false
+	}
+	return expr[1:closeIdx], true
+}
+
+// luaMatchingParen returns the index of the ')' closing the '(' at open.
+func luaMatchingParen(s string, open int) (int, bool) {
+	depth := 0
+	for i := open; i < len(s); i++ {
+		c := s[i]
+		if c == '\'' || c == '"' {
+			if next, ok := skipLuaShortString(s, i); ok {
+				i = next - 1
+				continue
+			}
+		}
+		switch c {
+		case '(':
+			depth++
+		case ')':
+			depth--
+			if depth == 0 {
+				return i, true
+			}
+		}
+	}
+	return 0, false
+}
+
+// parseLuaSingleStringLiteral reports whether expr is exactly one string literal.
+func parseLuaSingleStringLiteral(expr string) (string, bool) {
+	if value, next, ok := parseLuaLongBracket(expr, 0); ok && strings.TrimSpace(expr[next:]) == "" {
+		return value, true
+	}
+	if expr == "" || (expr[0] != '\'' && expr[0] != '"') {
+		return "", false
+	}
+	quote := expr[0]
+	for i := 1; i < len(expr); i++ {
+		if expr[i] == '\\' {
+			i++
+			continue
+		}
+		if expr[i] == quote {
+			if strings.TrimSpace(expr[i+1:]) != "" {
+				return "", false
+			}
+			return expr[1:i], true
+		}
+	}
+	return "", false
 }

--- a/internal/config/hyprland_lua.go
+++ b/internal/config/hyprland_lua.go
@@ -35,26 +35,63 @@ func VerifyLuaIncludeChain(rootConfigPath string, targetPath string) error {
 		if err != nil {
 			return err
 		}
+		state = retry
 	}
 	if ok {
 		return nil
 	}
 
-	return fmt.Errorf("%s is not included by %s; add `%s` to your Hyprland Lua config or pass a different --monitors-conf target", targetPath, rootConfigPath, luaIncludeSuggestion(rootConfigPath, targetPath))
+	return fmt.Errorf("%s is not included by %s; add `%s` to your Hyprland Lua config or pass a different --monitors-conf target", targetPath, rootConfigPath, luaIncludeSuggestion(rootConfigPath, targetPath, state.patterns))
 }
 
-func luaIncludeSuggestion(rootConfigPath string, targetPath string) string {
-	rootDir := filepath.Dir(rootConfigPath)
-	targetDir := filepath.Dir(targetPath)
-	if targetDir == rootDir {
-		moduleName := strings.TrimSuffix(filepath.Base(targetPath), filepath.Ext(targetPath))
+// luaIncludeSuggestion proposes a line the user can paste into their config.
+// It only suggests a require() it can show will actually resolve: when the
+// config drives module lookup through package.path, a directory-relative module
+// name is not loadable, and suggesting one sends the user to a "module not
+// found" error. In that case fall back to dofile(), which is position
+// independent and always resolves.
+func luaIncludeSuggestion(rootConfigPath string, targetPath string, patterns []string) string {
+	if moduleName, ok := luaModuleNameFromPatterns(targetPath, patterns); ok {
 		return "require(" + quoteLuaArg(moduleName) + ")"
 	}
-	if rel, err := filepath.Rel(rootDir, targetPath); err == nil && !isParentRelativePath(rel) {
-		moduleName := strings.TrimSuffix(rel, filepath.Ext(rel))
-		return "require(" + quoteLuaArg(filepath.ToSlash(moduleName)) + ")"
+
+	// No package.path in play: keep the historical directory-relative guess.
+	if len(patterns) == 0 {
+		rootDir := filepath.Dir(rootConfigPath)
+		targetDir := filepath.Dir(targetPath)
+		if targetDir == rootDir {
+			moduleName := strings.TrimSuffix(filepath.Base(targetPath), filepath.Ext(targetPath))
+			return "require(" + quoteLuaArg(moduleName) + ")"
+		}
+		if rel, err := filepath.Rel(rootDir, targetPath); err == nil && !isParentRelativePath(rel) {
+			moduleName := strings.TrimSuffix(rel, filepath.Ext(rel))
+			return "require(" + quoteLuaArg(filepath.ToSlash(moduleName)) + ")"
+		}
 	}
+
 	return "dofile(" + quoteLuaArg(targetPath) + ")"
+}
+
+// luaModuleNameFromPatterns inverts a package.path pattern to recover the module
+// name that would load targetPath, so the suggestion matches the convention the
+// config already uses (e.g. "hypr.monitors" rather than a bare "monitors").
+func luaModuleNameFromPatterns(targetPath string, patterns []string) (string, bool) {
+	for _, pattern := range patterns {
+		idx := strings.Index(pattern, "?")
+		if idx < 0 {
+			continue
+		}
+		prefix, suffix := pattern[:idx], pattern[idx+1:]
+		if !strings.HasPrefix(targetPath, prefix) || !strings.HasSuffix(targetPath, suffix) {
+			continue
+		}
+		name := targetPath[len(prefix) : len(targetPath)-len(suffix)]
+		if name == "" {
+			continue
+		}
+		return strings.ReplaceAll(filepath.ToSlash(name), "/", "."), true
+	}
+	return "", false
 }
 
 func quoteLuaArg(value string) string {

--- a/internal/config/hyprland_test.go
+++ b/internal/config/hyprland_test.go
@@ -992,3 +992,149 @@ func TestVerifyLuaSourceChainSuggestsAbsoluteDofileForCustomTarget(t *testing.T)
 		t.Fatalf("expected absolute dofile suggestion %s, got %v", want, err)
 	}
 }
+
+func TestVerifyLuaSourceChainFollowsComputedDofilePackagePath(t *testing.T) {
+	root := t.TempDir()
+	home := filepath.Join(root, "home")
+	hypr := filepath.Join(home, ".config", "hypr")
+	omarchy := filepath.Join(root, "share", "omarchy")
+	share := filepath.Join(omarchy, "default", "hypr")
+	for _, dir := range []string{hypr, share} {
+		if err := os.MkdirAll(dir, 0o755); err != nil {
+			t.Fatalf("mkdir %s: %v", dir, err)
+		}
+	}
+
+	t.Setenv("HOME", home)
+	t.Setenv("OMARCHY_PATH", omarchy)
+
+	bootstrap := `package.path = os.getenv("HOME")
+  .. "/.config/?.lua;"
+  .. package.path
+`
+	if err := os.WriteFile(filepath.Join(share, "bootstrap.lua"), []byte(bootstrap), 0o644); err != nil {
+		t.Fatalf("write bootstrap: %v", err)
+	}
+
+	rootConfig := filepath.Join(hypr, "hyprland.lua")
+	content := `dofile((os.getenv("OMARCHY_PATH") or "/usr/share/omarchy") .. "/default/hypr/bootstrap.lua")
+require("hypr.monitors")
+`
+	if err := os.WriteFile(rootConfig, []byte(content), 0o644); err != nil {
+		t.Fatalf("write root config: %v", err)
+	}
+	target := filepath.Join(hypr, "monitors.lua")
+	if err := os.WriteFile(target, []byte("-- generated\n"), 0o644); err != nil {
+		t.Fatalf("write target config: %v", err)
+	}
+
+	if err := VerifyIncludeChain(HyprConfigLua, rootConfig, target); err != nil {
+		t.Fatalf("expected package.path from a computed dofile to verify, got %v", err)
+	}
+}
+
+func TestVerifyLuaSourceChainFollowsComputedDofileFallbackBranch(t *testing.T) {
+	root := t.TempDir()
+	home := filepath.Join(root, "home")
+	hypr := filepath.Join(home, ".config", "hypr")
+	omarchy := filepath.Join(root, "share", "omarchy")
+	share := filepath.Join(omarchy, "default", "hypr")
+	for _, dir := range []string{hypr, share} {
+		if err := os.MkdirAll(dir, 0o755); err != nil {
+			t.Fatalf("mkdir %s: %v", dir, err)
+		}
+	}
+
+	t.Setenv("HOME", home)
+	os.Unsetenv("HYPRMONCFG_TEST_UNSET_BASE")
+
+	bootstrap := `package.path = os.getenv("HOME") .. "/.config/?.lua;" .. package.path
+`
+	if err := os.WriteFile(filepath.Join(share, "bootstrap.lua"), []byte(bootstrap), 0o644); err != nil {
+		t.Fatalf("write bootstrap: %v", err)
+	}
+
+	rootConfig := filepath.Join(hypr, "hyprland.lua")
+	content := `dofile((os.getenv("HYPRMONCFG_TEST_UNSET_BASE") or "` +
+		filepath.ToSlash(omarchy) + `") .. "/default/hypr/bootstrap.lua")
+require("hypr.monitors")
+`
+	if err := os.WriteFile(rootConfig, []byte(content), 0o644); err != nil {
+		t.Fatalf("write root config: %v", err)
+	}
+	target := filepath.Join(hypr, "monitors.lua")
+	if err := os.WriteFile(target, []byte("-- generated\n"), 0o644); err != nil {
+		t.Fatalf("write target config: %v", err)
+	}
+
+	if err := VerifyIncludeChain(HyprConfigLua, rootConfig, target); err != nil {
+		t.Fatalf("expected the literal `or` fallback branch to verify, got %v", err)
+	}
+}
+
+func TestVerifyLuaSourceChainAppliesPackagePathAssignedAfterRequire(t *testing.T) {
+	root := t.TempDir()
+	home := filepath.Join(root, "home")
+	hypr := filepath.Join(home, ".config", "hypr")
+	if err := os.MkdirAll(hypr, 0o755); err != nil {
+		t.Fatalf("mkdir hypr dir: %v", err)
+	}
+
+	t.Setenv("HOME", home)
+	rootConfig := filepath.Join(hypr, "hyprland.lua")
+	content := `require("hypr.monitors")
+package.path = os.getenv("HOME") .. "/.config/?.lua;" .. package.path
+`
+	if err := os.WriteFile(rootConfig, []byte(content), 0o644); err != nil {
+		t.Fatalf("write root config: %v", err)
+	}
+	target := filepath.Join(hypr, "monitors.lua")
+	if err := os.WriteFile(target, []byte("-- generated\n"), 0o644); err != nil {
+		t.Fatalf("write target config: %v", err)
+	}
+
+	if err := VerifyIncludeChain(HyprConfigLua, rootConfig, target); err != nil {
+		t.Fatalf("expected package.path assigned after the require to verify, got %v", err)
+	}
+}
+
+func TestEvalLuaStringExpression(t *testing.T) {
+	t.Setenv("HYPRMONCFG_TEST_BASE", "/opt/base")
+	os.Unsetenv("HYPRMONCFG_TEST_ABSENT")
+
+	tests := []struct {
+		name string
+		expr string
+		want []string
+	}{
+		{name: "plain literal", expr: `"/etc/x.lua"`, want: []string{"/etc/x.lua"}},
+		{name: "concatenation", expr: `"/etc" .. "/x.lua"`, want: []string{"/etc/x.lua"}},
+		{name: "getenv", expr: `os.getenv("HYPRMONCFG_TEST_BASE") .. "/x.lua"`, want: []string{"/opt/base/x.lua"}},
+		{
+			name: "or keeps both branches",
+			expr: `(os.getenv("HYPRMONCFG_TEST_BASE") or "/fallback") .. "/x.lua"`,
+			want: []string{"/opt/base/x.lua", "/fallback/x.lua"},
+		},
+		{
+			name: "or falls back when unset",
+			expr: `(os.getenv("HYPRMONCFG_TEST_ABSENT") or "/fallback") .. "/x.lua"`,
+			want: []string{"/fallback/x.lua"},
+		},
+		{name: "unsupported call yields nothing", expr: `some_helper("x") .. "/x.lua"`, want: nil},
+		{name: "identifier containing or is not split", expr: `"for" .. "k.lua"`, want: []string{"fork.lua"}},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := evalLuaStringExpression(tt.expr)
+			if len(got) != len(tt.want) {
+				t.Fatalf("got %q, want %q", got, tt.want)
+			}
+			for i := range tt.want {
+				if got[i] != tt.want[i] {
+					t.Fatalf("got %q, want %q", got, tt.want)
+				}
+			}
+		})
+	}
+}

--- a/internal/config/hyprland_test.go
+++ b/internal/config/hyprland_test.go
@@ -1138,3 +1138,80 @@ func TestEvalLuaStringExpression(t *testing.T) {
 		})
 	}
 }
+
+func TestLuaIncludeSuggestionUsesPackagePathModuleName(t *testing.T) {
+	root := t.TempDir()
+	home := filepath.Join(root, "home")
+	hypr := filepath.Join(home, ".config", "hypr")
+	if err := os.MkdirAll(hypr, 0o755); err != nil {
+		t.Fatalf("mkdir hypr dir: %v", err)
+	}
+
+	t.Setenv("HOME", home)
+	rootConfig := filepath.Join(hypr, "hyprland.lua")
+	content := `package.path = os.getenv("HOME") .. "/.config/?.lua;" .. package.path
+require("hypr.something-else")
+`
+	if err := os.WriteFile(rootConfig, []byte(content), 0o644); err != nil {
+		t.Fatalf("write root config: %v", err)
+	}
+	target := filepath.Join(hypr, "generated.lua")
+
+	err := VerifyIncludeChain(HyprConfigLua, rootConfig, target)
+	if err == nil {
+		t.Fatal("expected verification to fail for an unincluded target")
+	}
+	// Must match the convention the config already uses, not a bare "generated"
+	// which package.path cannot load.
+	if !strings.Contains(err.Error(), "require(\"hypr.generated\")") {
+		t.Fatalf("expected package.path-aware require suggestion, got %v", err)
+	}
+}
+
+func TestLuaIncludeSuggestionFallsBackToDofileOutsidePackagePath(t *testing.T) {
+	root := t.TempDir()
+	home := filepath.Join(root, "home")
+	hypr := filepath.Join(home, ".config", "hypr")
+	if err := os.MkdirAll(hypr, 0o755); err != nil {
+		t.Fatalf("mkdir hypr dir: %v", err)
+	}
+
+	t.Setenv("HOME", home)
+	rootConfig := filepath.Join(hypr, "hyprland.lua")
+	content := `package.path = os.getenv("HOME") .. "/.config/?.lua;" .. package.path
+require("hypr.something-else")
+`
+	if err := os.WriteFile(rootConfig, []byte(content), 0o644); err != nil {
+		t.Fatalf("write root config: %v", err)
+	}
+	// Outside every declared package.path prefix, so no require() can load it.
+	target := filepath.Join(root, "elsewhere", "generated.lua")
+
+	err := VerifyIncludeChain(HyprConfigLua, rootConfig, target)
+	if err == nil {
+		t.Fatal("expected verification to fail for an unincluded target")
+	}
+	if !strings.Contains(err.Error(), "dofile(") {
+		t.Fatalf("expected dofile fallback suggestion, got %v", err)
+	}
+	if strings.Contains(err.Error(), "require(") {
+		t.Fatalf("expected no unresolvable require suggestion, got %v", err)
+	}
+}
+
+func TestLuaIncludeSuggestionKeepsRelativeRequireWithoutPackagePath(t *testing.T) {
+	root := t.TempDir()
+	rootConfig := filepath.Join(root, "hyprland.lua")
+	if err := os.WriteFile(rootConfig, []byte("-- nothing included\n"), 0o644); err != nil {
+		t.Fatalf("write root config: %v", err)
+	}
+	target := filepath.Join(root, "monitors.lua")
+
+	err := VerifyIncludeChain(HyprConfigLua, rootConfig, target)
+	if err == nil {
+		t.Fatal("expected verification to fail for an unincluded target")
+	}
+	if !strings.Contains(err.Error(), "require(\"monitors\")") {
+		t.Fatalf("expected historical relative require suggestion, got %v", err)
+	}
+}


### PR DESCRIPTION
Fixes #39.

> **Stacked on #40** — branched from it because the suggestion can only be checked once `package.path` assigned in an included file is discoverable. Reviewing #40 first will make this diff read as ~60 lines. Happy to rebase onto `main` if you'd rather take them in the other order, or squash both into one PR.

## Problem

`VerifyLuaIncludeChain` derives its suggestion purely from path arithmetic and never checks the module name it proposes is loadable:

```go
if targetDir == rootDir {
    moduleName := strings.TrimSuffix(filepath.Base(targetPath), filepath.Ext(targetPath))
    return "require(" + quoteLuaArg(moduleName) + ")"
}
```

That assumes Lua searches the root config's own directory. On a `package.path`-driven config it doesn't, so the user is told to add a line that raises `module 'monitors' not found`. On Omarchy it's also a duplicate of a `require()` already in the file — and if `package.path` happened to permit both spellings, the module would load twice, since Lua caches by module *name*, not resolved path.

## Change

Invert the declared `package.path` patterns to recover the module name that actually loads the target, so the suggestion matches the convention the config already uses. Given `package.path` containing `$HOME/.config/?.lua` and a target of `~/.config/hypr/monitors.lua`, that yields `require("hypr.monitors")` rather than a bare `require("monitors")`.

When the target sits outside every declared prefix, fall back to the absolute `dofile()` form the function already has at the bottom — position independent and always resolvable.

Configs that declare no `package.path` are untouched and keep the historical directory-relative suggestion.

## Tests

Three added, full suite 316 → 326 green, `go vet` and `gofmt` clean:

- `TestLuaIncludeSuggestionUsesPackagePathModuleName` — suggests `require("hypr.generated")`, not `require("generated")`.
- `TestLuaIncludeSuggestionFallsBackToDofileOutsidePackagePath` — asserts `dofile(` is suggested **and** that no unresolvable `require(` appears.
- `TestLuaIncludeSuggestionKeepsRelativeRequireWithoutPackagePath` — pins the unchanged no-`package.path` behaviour.

Checked against a real unmodified Omarchy 4 config on disk: for a target of `~/.config/hypr/hyprmoncfg-monitors.lua` it now emits

```
add `require("hypr.hyprmoncfg-monitors")`
```

which is exactly the line that makes the config work — previously it suggested `require("hyprmoncfg-monitors")`, which does not load.
