### PR TITLE
Keep Omarchy Display panel scale instead of reverting it

### DIFF
--- a/docs/_guide/daemon.md
+++ b/docs/_guide/daemon.md
@@ -55,6 +55,8 @@ When the daemon detects a monitor or lid-state change, it runs through these ste
 
 If the winning profile is the same one that's already applied, the daemon skips re-applying it. You won't see unnecessary reloads.
 
+On Omarchy, a scale change from the built-in Display panel is treated as an edit to the active profile rather than an external drift to revert. The daemon recognizes it from `~/.local/state/omarchy/monitor-scaling.log` (written only by that panel and Super+/), saves the new scale, and re-applies the rest of the layout. See [Omarchy Quattro Panel](/omarchy/).
+
 When every enabled display is DPMS-off, the daemon treats monitor add/remove events as part of display sleep rather than physical hotplug. It keeps the current profile in place, waits for the displays to wake, and then waits for two seconds without another monitor event before matching once. A real dock or undock that happened while the machine slept is still applied after the monitor set stabilizes.
 
 Suspend gets the same respect. The daemon listens for logind's sleep signal, and a lid close that suspends the machine is treated as suspend, not clamshell: the pending switch is discarded instead of being carried across the nap, because by the time it would run, the lid is open again and acting on the stale close would turn the panel off in your face. On resume the daemon re-reads the physical lid switch, tells Hyprland to wake every display -- so both screens light up from the lid opening, not from your first keypress -- and re-matches once the monitor set settles. Opening the lid wakes the displays the same way. As a last line of defense, every apply re-reads the lid switch first, so a stale cached lid state can never decide what happens to your panel.

--- a/docs/_guide/omarchy.md
+++ b/docs/_guide/omarchy.md
@@ -44,6 +44,8 @@ Omarchy manages monitors too, and two managers can disagree. Three things keep h
 
 Omarchy's clamshell script also drives Hyprland directly with `hyprctl`, which no load order can outrank. The daemon covers that by putting the whole profile back when something outside hyprmoncfg moves the displays, including a profile you picked by hand.
 
+The Omarchy **Display** panel (and Super+/) is the exception. It records each scale change in `~/.local/state/omarchy/monitor-scaling.log` and does not go through hyprmoncfg. When the daemon sees a live scale that matches a recent line in that log, it writes the new scale into the active profile and then re-applies the saved layout. Clamshell and the monitor watcher do not write that log, so they are still reverted.
+
 Check the load order at any time:
 
 ```bash

--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -13,6 +13,7 @@ import (
 	"github.com/crmne/hyprmoncfg/internal/config"
 	"github.com/crmne/hyprmoncfg/internal/hypr"
 	"github.com/crmne/hyprmoncfg/internal/lid"
+	"github.com/crmne/hyprmoncfg/internal/omarchywatch"
 	"github.com/crmne/hyprmoncfg/internal/profile"
 	"github.com/crmne/hyprmoncfg/internal/suspend"
 )
@@ -538,6 +539,8 @@ func (s *Service) applyBest(ctx context.Context) error {
 		}
 	}
 
+	target = s.absorbOmarchyDisplayScale(target, monitors, monitorSet, manualHold)
+
 	effective := target
 	if s.lidState == lid.Closed {
 		adjusted, adjustment := profile.ApplyClosedLidPolicy(target, monitors)
@@ -585,6 +588,33 @@ func (s *Service) applyBest(ctx context.Context) error {
 	s.cfg.Logf("applied profile: %s", target.Name)
 	s.signalChange()
 	return nil
+}
+
+// absorbOmarchyDisplayScale keeps a scale the Omarchy Display panel just
+// set. That panel talks to Hyprland directly, so without this the next
+// poll would put the saved profile back and undo the click. Clamshell
+// resets do not write Omarchy's scaling log, so they still get reverted.
+func (s *Service) absorbOmarchyDisplayScale(target profile.Profile, monitors []hypr.Monitor, monitorSet string, manualHold bool) profile.Profile {
+	if target.Name == "" {
+		return target
+	}
+	if _, err := s.store.Load(target.Name); err != nil {
+		return target
+	}
+
+	updated, changed := profile.AbsorbRequestedScales(target, monitors, omarchywatch.RecentRequestedScales(time.Now()))
+	if len(changed) == 0 {
+		return target
+	}
+	if err := s.store.Save(updated); err != nil {
+		s.cfg.Logf("could not persist Omarchy display scale into %q: %v", target.Name, err)
+		return target
+	}
+	if manualHold {
+		s.setManualOverride(monitorSet, updated)
+	}
+	s.cfg.Logf("persisted Omarchy display scale for %s into profile %q", strings.Join(changed, ","), updated.Name)
+	return updated
 }
 
 func (s *Service) SetNotifier(notify func()) {

--- a/internal/daemon/daemon_test.go
+++ b/internal/daemon/daemon_test.go
@@ -461,6 +461,7 @@ func newRunTestEnv(t *testing.T, monitors []hypr.Monitor) runTestEnv {
 	t.Helper()
 
 	dir := t.TempDir()
+	t.Setenv("XDG_STATE_HOME", dir)
 	logPath := filepath.Join(dir, "hyprctl.log")
 	monitorStatePath := filepath.Join(dir, "monitors.json")
 	monitorsConfPath := filepath.Join(dir, "monitors.conf")
@@ -743,6 +744,7 @@ func newApplyBestTestEnvWithMonitors(t *testing.T, beforeApplyMonitorsJSON, afte
 	t.Helper()
 
 	dir := t.TempDir()
+	t.Setenv("XDG_STATE_HOME", dir)
 	logPath := filepath.Join(dir, "hyprctl.log")
 	statePath := filepath.Join(dir, "applied")
 	monitorsConfPath := filepath.Join(dir, "monitors.conf")
@@ -883,6 +885,72 @@ func TestApplyBestRestoresTheManuallyChosenProfileAfterAnExternalChange(t *testi
 	}
 	if strings.Contains(rendered, "scale = 3") {
 		t.Fatalf("expected the manual choice to outrank automatic matching:\n%s", rendered)
+	}
+}
+
+func TestApplyBestPersistsOmarchyDisplayPanelScale(t *testing.T) {
+	// Omarchy's Display panel changed scale via hyprctl and left position=auto.
+	// Keep the new scale, put the saved layout back.
+	drifted := `[{"id":1,"name":"eDP-1","description":"Framework Panel","make":"Framework","model":"Panel","serial":"A1","width":2880,"height":1800,"refreshRate":120,"x":0,"y":0,"scale":1.25,"transform":0,"disabled":false,"dpmsStatus":true,"mirrorOf":""}]`
+	restored := `[{"id":1,"name":"eDP-1","description":"Framework Panel","make":"Framework","model":"Panel","serial":"A1","width":2880,"height":1800,"refreshRate":120,"x":100,"y":200,"scale":1.25,"transform":0,"disabled":false,"dpmsStatus":true,"mirrorOf":""}]`
+	env := newApplyBestTestEnvWithMonitors(t, drifted, restored)
+	mon := hypr.Monitor{Name: "eDP-1", Description: "Framework Panel", Make: "Framework", Model: "Panel", Serial: "A1"}
+
+	if err := os.MkdirAll(filepath.Join(os.Getenv("XDG_STATE_HOME"), "omarchy"), 0o755); err != nil {
+		t.Fatalf("mkdir omarchy state: %v", err)
+	}
+	line := fmt.Sprintf("at=%s\trequested=1.25\tcurrent=1.5\tnew=1.25\tmonitor=eDP-1\n", time.Now().Format(time.RFC3339))
+	if err := os.WriteFile(filepath.Join(os.Getenv("XDG_STATE_HOME"), "omarchy", "monitor-scaling.log"), []byte(line), 0o644); err != nil {
+		t.Fatalf("write scaling log: %v", err)
+	}
+
+	chosen := profile.New("hand-picked", []profile.OutputConfig{{
+		Key:     mon.HardwareKey(),
+		Name:    mon.Name,
+		Enabled: true,
+		Width:   2880,
+		Height:  1800,
+		Refresh: 120,
+		X:       100,
+		Y:       200,
+		Scale:   1.5,
+	}})
+	if err := env.store.Save(chosen); err != nil {
+		t.Fatalf("save profile: %v", err)
+	}
+
+	logs := &logRecorder{}
+	svc := New(env.client, env.store, Config{
+		MonitorsConf: env.monitorsConfPath,
+		HyprConfig:   env.hyprlandConfigPath,
+		Logf:         logs.logf,
+	})
+	svc.setManualOverride(profile.MonitorSetHash([]hypr.Monitor{mon}), chosen)
+
+	if err := svc.applyBest(context.Background()); err != nil {
+		t.Fatalf("applyBest returned error: %v", err)
+	}
+
+	rendered := readMonitorsConf(t, env)
+	for _, want := range []string{"position = 100x200", "scale = 1.25"} {
+		if !strings.Contains(rendered, want) {
+			t.Fatalf("expected saved layout with Omarchy scale, missing %q:\n%s", want, rendered)
+		}
+	}
+	if strings.Contains(rendered, "scale = 1.5") {
+		t.Fatalf("Omarchy display scale was reverted:\n%s", rendered)
+	}
+	if !logs.contains("persisted Omarchy display scale for eDP-1 into profile \"hand-picked\"") {
+		t.Fatalf("expected persist log, got:\n%s", logs.all())
+	}
+
+	saved, err := env.store.Load("hand-picked")
+	if err != nil {
+		t.Fatalf("reload profile: %v", err)
+	}
+	got, ok := saved.OutputByKey(mon.HardwareKey())
+	if !ok || got.Scale != 1.25 || got.X != 100 || got.Y != 200 {
+		t.Fatalf("saved output = %+v", got)
 	}
 }
 

--- a/internal/omarchywatch/scalinglog.go
+++ b/internal/omarchywatch/scalinglog.go
@@ -1,0 +1,132 @@
+package omarchywatch
+
+import (
+	"bufio"
+	"bytes"
+	"io"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"time"
+)
+
+const (
+	// Omarchy's Display panel and Super+/ scaler append one line here for
+	// every successful set. Clamshell and the monitor watcher do not.
+	scaleLogRelPath = "omarchy/monitor-scaling.log"
+
+	// Long enough to cover hyprmoncfgd's 5s poll plus debounce, short enough
+	// that an old click cannot rewrite a profile after a later clamshell reset.
+	ScaleLogMaxAge = 15 * time.Second
+
+	scaleLogReadTail = 32 * 1024
+)
+
+// RecentRequestedScales returns the newest Omarchy Display-panel scale
+// request per connector that is no older than ScaleLogMaxAge.
+func RecentRequestedScales(now time.Time) map[string]float64 {
+	return ParseRequestedScales(readScaleLogTail(), now, ScaleLogMaxAge)
+}
+
+func readScaleLogTail() []byte {
+	path := scaleLogPath()
+	if path == "" {
+		return nil
+	}
+	file, err := os.Open(path)
+	if err != nil {
+		return nil
+	}
+	defer file.Close()
+
+	info, err := file.Stat()
+	if err != nil {
+		return nil
+	}
+	start := info.Size() - scaleLogReadTail
+	if start < 0 {
+		start = 0
+	}
+	if start > 0 {
+		if _, err := file.Seek(start, io.SeekStart); err != nil {
+			return nil
+		}
+	}
+	data, err := io.ReadAll(file)
+	if err != nil {
+		return nil
+	}
+	return data
+}
+
+func scaleLogPath() string {
+	state := os.Getenv("XDG_STATE_HOME")
+	if state == "" {
+		home, err := os.UserHomeDir()
+		if err != nil || home == "" {
+			return ""
+		}
+		state = filepath.Join(home, ".local", "state")
+	}
+	return filepath.Join(state, scaleLogRelPath)
+}
+
+// ParseRequestedScales is the testable core of RecentRequestedScales.
+func ParseRequestedScales(data []byte, now time.Time, maxAge time.Duration) map[string]float64 {
+	if len(data) == 0 || maxAge <= 0 {
+		return nil
+	}
+
+	requested := make(map[string]float64)
+	seenAt := make(map[string]time.Time)
+	scanner := bufio.NewScanner(bytes.NewReader(data))
+	for scanner.Scan() {
+		monitor, scale, at, ok := parseScaleLogLine(scanner.Text())
+		if !ok {
+			continue
+		}
+		if now.Sub(at) > maxAge || at.After(now.Add(time.Second)) {
+			continue
+		}
+		if previous, exists := seenAt[monitor]; exists && !at.After(previous) {
+			continue
+		}
+		requested[monitor] = scale
+		seenAt[monitor] = at
+	}
+	if len(requested) == 0 {
+		return nil
+	}
+	return requested
+}
+
+func parseScaleLogLine(line string) (string, float64, time.Time, bool) {
+	line = strings.TrimSpace(line)
+	if line == "" || strings.HasPrefix(line, "#") {
+		return "", 0, time.Time{}, false
+	}
+
+	fields := make(map[string]string)
+	for _, field := range strings.Split(line, "\t") {
+		key, value, ok := strings.Cut(field, "=")
+		if !ok {
+			continue
+		}
+		fields[key] = value
+	}
+
+	at, err := time.Parse(time.RFC3339, fields["at"])
+	if err != nil {
+		return "", 0, time.Time{}, false
+	}
+	scale, err := strconv.ParseFloat(fields["new"], 64)
+	if err != nil || scale <= 0 {
+		return "", 0, time.Time{}, false
+	}
+	monitor := strings.TrimSpace(fields["monitor"])
+	if monitor == "" {
+		return "", 0, time.Time{}, false
+	}
+	return monitor, scale, at, true
+}

--- a/internal/omarchywatch/scalinglog_test.go
+++ b/internal/omarchywatch/scalinglog_test.go
@@ -1,0 +1,42 @@
+package omarchywatch
+
+import (
+	"testing"
+	"time"
+)
+
+func TestParseRequestedScalesKeepsNewestInWindow(t *testing.T) {
+	now := time.Date(2026, 8, 19, 17, 3, 0, 0, time.FixedZone("CEST", 2*3600))
+	log := "" +
+		"at=2026-08-19T17:02:41+02:00\trequested=1.25\tcurrent=2\tnew=1.25\tmonitor=eDP-1\n" +
+		"at=2026-08-19T17:02:55+02:00\trequested=1.6\tcurrent=1.25\tnew=1.6\tmonitor=eDP-1\n" +
+		"at=2026-08-19T17:02:50+02:00\trequested=1.25\tcurrent=1\tnew=1.25\tmonitor=HDMI-A-1\n"
+
+	got := ParseRequestedScales([]byte(log), now, 15*time.Second)
+	if got["eDP-1"] != 1.6 {
+		t.Fatalf("eDP-1 scale = %v, want 1.6", got["eDP-1"])
+	}
+	if got["HDMI-A-1"] != 1.25 {
+		t.Fatalf("HDMI-A-1 scale = %v, want 1.25", got["HDMI-A-1"])
+	}
+}
+
+func TestParseRequestedScalesDropsStaleAndFutureLines(t *testing.T) {
+	now := time.Date(2026, 8, 19, 17, 3, 0, 0, time.UTC)
+	log := "" +
+		"at=2026-08-19T17:02:00Z\tnew=1.25\tmonitor=eDP-1\n" +
+		"at=2026-08-19T17:04:00Z\tnew=1.6\tmonitor=eDP-1\n"
+
+	if got := ParseRequestedScales([]byte(log), now, 15*time.Second); got != nil {
+		t.Fatalf("expected no recent requests, got %v", got)
+	}
+}
+
+func TestParseRequestedScalesIgnoresJunk(t *testing.T) {
+	now := time.Date(2026, 8, 19, 17, 3, 0, 0, time.UTC)
+	log := "not a log line\nat=nope\tnew=1\tmonitor=eDP-1\n\n"
+
+	if got := ParseRequestedScales([]byte(log), now, time.Minute); got != nil {
+		t.Fatalf("expected nil, got %v", got)
+	}
+}

--- a/internal/profile/match.go
+++ b/internal/profile/match.go
@@ -342,3 +342,44 @@ func ScaleMatchesRoundedReadback(width, height int, savedScale, reportedScale fl
 func roundScaleForHyprlandReadback(scale float64) float64 {
 	return math.Round(scale*100) / 100
 }
+
+// AbsorbRequestedScales copies connector scales from requested into the
+// matching enabled outputs when Hyprland has already landed on that value.
+// Position, mode, and enablement stay as the profile saved them.
+func AbsorbRequestedScales(p Profile, monitors []hypr.Monitor, requested map[string]float64) (Profile, []string) {
+	p.Normalize()
+	if len(requested) == 0 || len(p.Outputs) == 0 || len(monitors) == 0 {
+		return p, nil
+	}
+
+	resolver := NewMonitorResolver(monitors)
+	updated := p
+	updated.Outputs = append([]OutputConfig(nil), p.Outputs...)
+	var changed []string
+
+	for i, output := range updated.Outputs {
+		if !output.Enabled {
+			continue
+		}
+		monitor, ok := resolver.ResolveOutput(output)
+		if !ok || monitor.Disabled {
+			continue
+		}
+		want, ok := requested[monitor.Name]
+		if !ok || want <= 0 {
+			continue
+		}
+		if !stateScalesEqual(monitor.Width, monitor.Height, monitor.Scale, want) {
+			continue
+		}
+		if stateScalesEqual(monitor.Width, monitor.Height, output.Scale, want) {
+			continue
+		}
+		updated.Outputs[i].Scale = want
+		changed = append(changed, monitor.Name)
+	}
+	if len(changed) == 0 {
+		return p, nil
+	}
+	return updated, changed
+}

--- a/internal/profile/match_test.go
+++ b/internal/profile/match_test.go
@@ -281,6 +281,55 @@ func TestRoundedScaleReadbackRequiresSharpSavedScale(t *testing.T) {
 	}
 }
 
+func TestAbsorbRequestedScalesKeepsLayoutAndUpdatesMatchingOutput(t *testing.T) {
+	laptop := hypr.Monitor{
+		Name: "eDP-1", Make: "BOE", Model: "Panel", Serial: "C3",
+		Width: 1920, Height: 1080, RefreshRate: 144, X: 0, Y: 0, Scale: 1.25,
+	}
+	external := hypr.Monitor{
+		Name: "HDMI-A-1", Make: "LG", Model: "FHD", Serial: "D4",
+		Width: 1920, Height: 1080, RefreshRate: 60, X: 1920, Y: 76, Scale: 1,
+	}
+	saved := New("desk", []OutputConfig{
+		{Key: laptop.HardwareKey(), Name: laptop.Name, Enabled: true, Width: 1920, Height: 1080, Refresh: 144, X: 1920, Y: 76, Scale: 2},
+		{Key: external.HardwareKey(), Name: external.Name, Enabled: true, Width: 1920, Height: 1080, Refresh: 60, X: 0, Y: -700, Scale: 1},
+	})
+
+	updated, changed := AbsorbRequestedScales(saved, []hypr.Monitor{laptop, external}, map[string]float64{"eDP-1": 1.25})
+	if len(changed) != 1 || changed[0] != "eDP-1" {
+		t.Fatalf("changed = %v, want [eDP-1]", changed)
+	}
+	laptopOut, ok := updated.OutputByKey(laptop.HardwareKey())
+	if !ok || laptopOut.Scale != 1.25 || laptopOut.X != 1920 || laptopOut.Y != 76 {
+		t.Fatalf("laptop output = %+v", laptopOut)
+	}
+	externalOut, ok := updated.OutputByKey(external.HardwareKey())
+	if !ok || externalOut.Scale != 1 || externalOut.X != 0 {
+		t.Fatalf("external output = %+v", externalOut)
+	}
+}
+
+func TestAbsorbRequestedScalesIgnoresUnlandedAndDisabledOutputs(t *testing.T) {
+	laptop := hypr.Monitor{
+		Name: "eDP-1", Make: "BOE", Model: "Panel", Serial: "C3",
+		Width: 1920, Height: 1080, Scale: 2,
+	}
+	saved := New("desk", []OutputConfig{
+		{Key: laptop.HardwareKey(), Name: laptop.Name, Enabled: true, Width: 1920, Height: 1080, Scale: 2},
+	})
+
+	if _, changed := AbsorbRequestedScales(saved, []hypr.Monitor{laptop}, map[string]float64{"eDP-1": 1.25}); changed != nil {
+		t.Fatalf("live scale did not land, changed = %v", changed)
+	}
+
+	disabled := laptop
+	disabled.Disabled = true
+	disabled.Scale = 1.25
+	if _, changed := AbsorbRequestedScales(saved, []hypr.Monitor{disabled}, map[string]float64{"eDP-1": 1.25}); changed != nil {
+		t.Fatalf("disabled output, changed = %v", changed)
+	}
+}
+
 func TestExactStateMatchTreatsOmittedDefaultsAsLiveDefaults(t *testing.T) {
 	monitors := []hypr.Monitor{{
 		Name: "DP-1", Make: "Microstep", Model: "MPG321UR-QD", Serial: "A1",


### PR DESCRIPTION
## Problem

On Omarchy, the built-in Display panel (and Super+/) sets monitor scale with `hyprctl` and does not go through hyprmoncfg. `hyprmoncfgd` treats that as external drift and restores the saved profile a few seconds later, so the scale snap-back is ~5s (`--poll-interval`).

Clamshell / the monitor watcher also drive Hyprland directly. Those resets should still be reverted.

## Approach

Omarchy's scaler already appends one line to `~/.local/state/omarchy/monitor-scaling.log` per successful set. Clamshell does not.

When live scale matches a recent line in that log (15s window), write the new scale into the active profile and re-apply the saved layout (position, mode, enablement). No log match → same restore-the-profile behavior as today.

## Tests

- `ParseRequestedScales` keeps the newest in-window request per connector and drops stale/junk lines
- `AbsorbRequestedScales` updates only the matching enabled output
- `TestApplyBestPersistsOmarchyDisplayPanelScale` keeps 1.25x and restores `position = 100x200`
- Existing `TestApplyBestRestoresTheManuallyChosenProfileAfterAnExternalChange` still reverts when there is no scaling log

`go test ./...` is green.