### PR TITLE
Remove the config include when reverting a first-time preview

### DIFF
--- a/internal/apply/apply.go
+++ b/internal/apply/apply.go
@@ -45,6 +45,8 @@ type Engine struct {
 type RevertState struct {
 	MonitorsConf config.FileSnapshot
 	Commands     []string
+	IncludeAdded bool
+	Resolved     config.ResolvedHyprConfig
 }
 
 type RenderOptions = render.Options
@@ -220,7 +222,8 @@ func (e Engine) Apply(ctx context.Context, p profile.Profile, monitors []hypr.Mo
 	// include has to be in place for it. The file it names is written just
 	// after this, and never before: an include pointing at a file that does not
 	// exist yet is a config error on any reload that lands in between.
-	e.ensureConfigInclude(resolvedConfig)
+	revertState.Resolved = resolvedConfig
+	revertState.IncludeAdded = e.ensureConfigInclude(resolvedConfig).Added
 	renderedForReload := rendered
 	luaProbe := ""
 	if resolvedConfig.Format == config.HyprConfigLua {
@@ -293,13 +296,13 @@ func (e Engine) Apply(ctx context.Context, p profile.Profile, monitors []hypr.Mo
 
 // ensureConfigInclude keeps the generated monitor config loaded last by the
 // root Hyprland config.
-func (e Engine) ensureConfigInclude(resolved config.ResolvedHyprConfig) {
+func (e Engine) ensureConfigInclude(resolved config.ResolvedHyprConfig) config.IncludeResult {
 	result, err := config.EnsureIncluded(resolved.RootPath, resolved.Format, resolved.MonitorsPath)
 	if err != nil {
 		if e.Logf != nil {
 			e.Logf("could not load %s from %s: %v", resolved.MonitorsPath, resolved.RootPath, err)
 		}
-		return
+		return config.IncludeResult{}
 	}
 	if result.Changed() && e.Logf != nil {
 		action := "moved to the end of"
@@ -308,7 +311,7 @@ func (e Engine) ensureConfigInclude(resolved config.ResolvedHyprConfig) {
 		}
 		e.Logf("%s %s: %s", action, result.RootPath, result.Line)
 	}
-
+	return result
 }
 
 // retireLegacyMonitorsFile empties the monitors file an older hyprmoncfg owned,
@@ -531,6 +534,11 @@ func (e Engine) Revert(ctx context.Context, state RevertState) error {
 	if state.MonitorsConf.Path != "" {
 		if err := state.MonitorsConf.Restore(); err != nil {
 			return err
+		}
+		if !state.MonitorsConf.Exists && state.IncludeAdded {
+			if _, err := config.RemoveInclude(state.Resolved.RootPath, state.Resolved.Format); err != nil {
+				return err
+			}
 		}
 		if err := e.Client.Reload(ctx); err != nil {
 			return err

--- a/internal/apply/apply.go
+++ b/internal/apply/apply.go
@@ -224,24 +224,40 @@ func (e Engine) Apply(ctx context.Context, p profile.Profile, monitors []hypr.Mo
 	// exist yet is a config error on any reload that lands in between.
 	revertState.Resolved = resolvedConfig
 	revertState.IncludeAdded = e.ensureConfigInclude(resolvedConfig).Added
+	// Every failure path below either never writes the monitors file or deletes
+	// it via backup.Restore(). An include this apply added must not outlive that
+	// file, or the root config errors on every later reload until the user
+	// removes the line by hand.
+	removeAddedInclude := func() {
+		if !revertState.IncludeAdded || backup.Exists {
+			return
+		}
+		if _, err := config.RemoveInclude(resolvedConfig.RootPath, resolvedConfig.Format); err != nil && e.Logf != nil {
+			e.Logf("could not remove include from %s: %v", resolvedConfig.RootPath, err)
+		}
+	}
 	renderedForReload := rendered
 	luaProbe := ""
 	if resolvedConfig.Format == config.HyprConfigLua {
 		renderedForReload, luaProbe, err = addLuaExecutionProbe(rendered)
 		if err != nil {
+			removeAddedInclude()
 			return RevertState{}, err
 		}
 	}
 	if err := config.WriteFileAtomic(resolvedConfig.MonitorsPath, []byte(renderedForReload), 0o644); err != nil {
+		removeAddedInclude()
 		return RevertState{}, err
 	}
 	if err := e.Client.Reload(ctx); err != nil {
 		_ = backup.Restore()
+		removeAddedInclude()
 		return RevertState{}, err
 	}
 	if luaProbe != "" {
 		if err := e.verifyLuaExecutionProbe(ctx, luaProbe, resolvedConfig.RootPath, resolvedConfig.MonitorsPath); err != nil {
 			restoreErr := backup.Restore()
+			removeAddedInclude()
 			reloadErr := e.Client.Reload(ctx)
 			return RevertState{}, errors.Join(
 				err,
@@ -254,6 +270,7 @@ func (e Engine) Apply(ctx context.Context, p profile.Profile, monitors []hypr.Mo
 		// uses a fresh probe, so the current Lua global cannot satisfy it.
 		if err := config.WriteFileAtomic(resolvedConfig.MonitorsPath, []byte(rendered), 0o644); err != nil {
 			restoreErr := backup.Restore()
+			removeAddedInclude()
 			reloadErr := e.Client.Reload(ctx)
 			return RevertState{}, errors.Join(
 				fmt.Errorf("remove Lua execution probe: %w", err),
@@ -266,6 +283,7 @@ func (e Engine) Apply(ctx context.Context, p profile.Profile, monitors []hypr.Mo
 	applied, err := e.waitForAppliedProfile(ctx, p, monitors)
 	if err != nil {
 		_ = backup.Restore()
+		removeAddedInclude()
 		_ = e.Client.Reload(ctx)
 		return RevertState{}, err
 	}
@@ -276,6 +294,7 @@ func (e Engine) Apply(ctx context.Context, p profile.Profile, monitors []hypr.Mo
 
 	if err := e.applyLiveCommands(ctx, workspaceCommandsForProfile(p, applied, luaDispatch)); err != nil {
 		_ = backup.Restore()
+		removeAddedInclude()
 		_ = e.Client.Reload(ctx)
 		_ = e.applyLiveCommands(ctx, revertState.Commands)
 		return RevertState{}, err

--- a/internal/apply/apply_test.go
+++ b/internal/apply/apply_test.go
@@ -1755,6 +1755,38 @@ func TestApplyNeverLeavesTheConfigWithoutMonitorRules(t *testing.T) {
 	}
 }
 
+func TestApplyFailureRemovesIncludeWhenPreviewNeverWroteFile(t *testing.T) {
+	engine, _, err := initTestEngine(t)
+	if err != nil {
+		t.Fatalf("init test engine: %v", err)
+	}
+
+	// First-time preview whose generated file cannot be written: the parent
+	// directory is read-only, so Apply fails right after adding the include.
+	// The path carries the "hyprmoncfg" marker, since RemoveInclude recognizes
+	// its own lines by it.
+	readonly := t.TempDir()
+	engine.MonitorsConfPath = filepath.Join(readonly, "hyprmoncfg-monitors.conf")
+	if err := os.WriteFile(engine.HyprlandConfigPath, nil, 0o644); err != nil {
+		t.Fatalf("truncate hyprland.conf: %v", err)
+	}
+	if err := os.Chmod(readonly, 0o500); err != nil {
+		t.Fatalf("chmod: %v", err)
+	}
+
+	if _, err := engine.Apply(context.Background(), newTestProfile(), monitors); err == nil {
+		t.Fatalf("expected apply to fail on unwritable monitors path")
+	}
+
+	root, err := os.ReadFile(engine.HyprlandConfigPath)
+	if err != nil {
+		t.Fatalf("read hyprland.conf: %v", err)
+	}
+	if strings.Contains(string(root), "hyprmoncfg") {
+		t.Fatalf("expected the added include to be removed, got:\n%s", root)
+	}
+}
+
 func TestEngineRevertRemovesIncludeWhenPreviewCreatedFile(t *testing.T) {
 	engine, _, err := initTestEngine(t)
 	if err != nil {

--- a/internal/apply/apply_test.go
+++ b/internal/apply/apply_test.go
@@ -1754,3 +1754,41 @@ func TestApplyNeverLeavesTheConfigWithoutMonitorRules(t *testing.T) {
 		t.Fatalf("expected a note pointing at the new file, got:\n%s", retired)
 	}
 }
+
+func TestEngineRevertRemovesIncludeWhenPreviewCreatedFile(t *testing.T) {
+	engine, _, err := initTestEngine(t)
+	if err != nil {
+		t.Fatalf("init test engine: %v", err)
+	}
+
+	// Simulate a first-time preview: neither the generated monitor config nor
+	// the include line exists yet. The path must carry the "hyprmoncfg"
+	// marker, since RemoveInclude recognizes its own lines by it.
+	engine.MonitorsConfPath = filepath.Join(filepath.Dir(engine.MonitorsConfPath), "hyprmoncfg-monitors.conf")
+	if err := os.WriteFile(engine.HyprlandConfigPath, nil, 0o644); err != nil {
+		t.Fatalf("truncate hyprland.conf: %v", err)
+	}
+
+	ctx := context.Background()
+	snapshot, err := engine.Apply(ctx, newTestProfile(), monitors)
+	if err != nil {
+		t.Fatalf("apply failed: %v", err)
+	}
+	if !snapshot.IncludeAdded {
+		t.Fatalf("expected the new include to be recorded in the revert state")
+	}
+	if err := engine.Revert(ctx, snapshot); err != nil {
+		t.Fatalf("revert failed: %v", err)
+	}
+
+	if _, err := os.Stat(engine.MonitorsConfPath); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("expected the generated monitor config to be removed, stat err: %v", err)
+	}
+	root, err := os.ReadFile(engine.HyprlandConfigPath)
+	if err != nil {
+		t.Fatalf("read hyprland.conf: %v", err)
+	}
+	if strings.Contains(string(root), "hyprmoncfg") {
+		t.Fatalf("expected the include line to be removed with the file, got:\n%s", root)
+	}
+}


### PR DESCRIPTION
## Problem

On a fresh setup (no profile ever applied), previewing a layout and then reverting leaves the config in a broken state:

1. `Apply` adds the `source`/`dofile` line for the generated monitor config to the root Hyprland config, then writes the generated file.
2. On revert, `FileSnapshot.Restore` sees the file did not exist before the preview and deletes it — but the include line stays behind.
3. Every subsequent Hyprland reload fails with:

```
cannot open /home/.../.config/hypr/hyprmoncfg-monitors.lua: No such file or directory
stack traceback:
	[C]: in global 'dofile'
	/home/.../.config/hypr/hyprland.lua:32: in main chunk
```

`hyprctl configerrors` keeps reporting it until the user removes the line or recreates the file by hand.

## Fix

Revert should undo everything the preview introduced, not just the generated file:

- `RevertState` now records whether `Apply` added the include (`IncludeAdded`) and carries the resolved config (`Resolved`) so `Revert` knows which root config and format to edit.
- `ensureConfigInclude` returns the `config.IncludeResult` instead of discarding it.
- `Revert` removes the include via the existing `config.RemoveInclude` (the documented inverse of `EnsureIncluded`, already used by `unmanage`) — but only when **both** the file and the include were created by this preview, so reverting over a pre-existing saved profile changes nothing.

The removal happens after `Restore()` deletes the file and before `Reload()`, so the reload itself never evaluates a dangling include.

## Reproduction (before this fix)

```bash
# fresh state: no profiles, no generated file, no include line
hyprmoncfg   # edit a layout -> preview -> revert
hyprctl reload
hyprctl configerrors
# => cannot open .../hyprmoncfg-monitors.lua: No such file or directory
```

After this fix the same flow leaves the root config untouched, the generated file removed, and `hyprctl configerrors` empty. Verified on a live Omarchy/Hyprland (Lua config format) setup with a locally built daemon.

## Tests

- Added `TestEngineRevertRemovesIncludeWhenPreviewCreatedFile`: apply over a state with no generated file and no include, revert, assert the file is gone **and** the root config contains no hyprmoncfg lines.
- `go test ./internal/apply/ ./internal/config/` passes. (`TestRunDefersTransientHotplugWhileDisplaysSleep` in `internal/daemon` fails on a clean checkout too — pre-existing flake, unrelated.)