### PR TITLE
Let a profile saved with cm = auto recognise its own state

### DIFF
--- a/internal/profile/match.go
+++ b/internal/profile/match.go
@@ -311,7 +311,7 @@ func outputConfigsShareEffectiveState(a, b OutputConfig) bool {
 		stateScalesEqual(a.Width, a.Height, a.Scale, b.Scale) &&
 		a.Transform == b.Transform &&
 		effectiveBitdepth(a.Bitdepth) == effectiveBitdepth(b.Bitdepth) &&
-		effectiveCM(a.CM) == effectiveCM(b.CM) &&
+		colorPresetsAgree(a.CM, b.CM) &&
 		effectiveSDRMultiplier(a.SDRBrightness) == effectiveSDRMultiplier(b.SDRBrightness) &&
 		effectiveSDRMultiplier(a.SDRSaturation) == effectiveSDRMultiplier(b.SDRSaturation) &&
 		a.SDRMinLuminance == b.SDRMinLuminance &&
@@ -331,6 +331,25 @@ func effectiveCM(value string) string {
 		return "srgb"
 	}
 	return value
+}
+
+// colorPresetsAgree compares a requested colour preset against a live one.
+//
+// "auto" is a request, not a result: Hyprland resolves it to a concrete preset
+// and reports that back, so a profile saved with cm = auto -- which is what
+// hyprmoncfg itself writes for an ordinary SDR display -- could never match its
+// own applied state under a string comparison. That is enough to make
+// ExactStateMatch never fire, leaving BestMatch to impose a different profile
+// over a desktop that needed no change at all.
+func colorPresetsAgree(a, b string) bool {
+	if isAutoColorPreset(a) || isAutoColorPreset(b) {
+		return true
+	}
+	return effectiveCM(a) == effectiveCM(b)
+}
+
+func isAutoColorPreset(value string) bool {
+	return strings.EqualFold(strings.TrimSpace(value), "auto")
 }
 
 func effectiveSDRMultiplier(value float64) float64 {

--- a/internal/profile/match_test.go
+++ b/internal/profile/match_test.go
@@ -453,3 +453,74 @@ func TestExactStateMatchIgnoresWhereHyprlandPutsAMirror(t *testing.T) {
 		t.Fatal("expected a profile that does not mirror to be a different state")
 	}
 }
+
+// "auto" is a colour-preset request, not a result: Hyprland resolves it and
+// reports back a concrete preset. Comparing the two as strings made a profile
+// unable to recognise its own applied state, which is exactly what hyprmoncfg
+// writes for an ordinary SDR display.
+func TestColorPresetAutoMatchesWhateverItResolvesTo(t *testing.T) {
+	cases := []struct {
+		saved string
+		live  string
+		want  bool
+	}{
+		{"auto", "srgb", true},
+		{"auto", "hdr", true},
+		{"AUTO", "srgb", true},
+		{"srgb", "auto", true},
+		{"", "srgb", true}, // empty means the default, which is srgb
+		{"srgb", "", true},
+		{"srgb", "srgb", true},
+		// A profile that genuinely asks for HDR must not match an SDR display.
+		{"hdr", "srgb", false},
+		{"srgb", "hdr", false},
+	}
+	for _, tc := range cases {
+		if got := colorPresetsAgree(tc.saved, tc.live); got != tc.want {
+			t.Fatalf("colorPresetsAgree(%q, %q) = %v, want %v", tc.saved, tc.live, got, tc.want)
+		}
+	}
+}
+
+// End to end: a saved profile has to recognise the desktop it describes, or
+// automatic switching imposes a different one over a layout that needed no
+// change at all. Reported on a two-display desktop, where turning the daemon on
+// silently mirrored the desk to the TV.
+func TestExactStateMatchRecognisesAProfileSavedWithAutoColor(t *testing.T) {
+	desk := hypr.Monitor{
+		Name: "DP-1", Description: "Dell U2720Q",
+		Make: "Dell", Model: "U2720Q", Serial: "A1",
+		Width: 2560, Height: 1440, RefreshRate: 60, Scale: 1,
+		ColorManagementPreset: "srgb", SDRMinLuminance: 0.2, SDRMaxLuminance: 80,
+	}
+	tv := hypr.Monitor{
+		Name: "HDMI-A-1", Description: "LG OLED65C1",
+		Make: "LG", Model: "OLED65C1", Serial: "B2",
+		Disabled: true, Scale: 1,
+	}
+	monitors := []hypr.Monitor{desk, tv}
+
+	// Saved by hyprmoncfg itself, which writes cm = auto for an SDR display.
+	saved := New("desk", []OutputConfig{
+		{
+			Key: desk.HardwareKey(), MatchKey: desk.HardwareKey(), Name: desk.Name,
+			Enabled: true, Mode: "2560x1440@60.00Hz",
+			Width: 2560, Height: 1440, Refresh: 60, Scale: 1,
+			CM: "auto", Bitdepth: 8, SDRMinLuminance: 0.2, SDRMaxLuminance: 80,
+			SDRBrightness: 1, SDRSaturation: 1,
+		},
+		{
+			Key: tv.HardwareKey(), MatchKey: tv.HardwareKey(), Name: tv.Name,
+			Enabled: false, Mode: "3840x2160@120.00Hz",
+			Width: 3840, Height: 2160, Refresh: 120, X: 2560, Scale: 1, CM: "hdr",
+		},
+	})
+
+	match, ok := ExactStateMatch([]Profile{saved}, monitors, nil)
+	if !ok {
+		t.Fatal("a profile must recognise the layout it describes")
+	}
+	if match.Name != "desk" {
+		t.Fatalf("matched %q", match.Name)
+	}
+}


### PR DESCRIPTION
> [!NOTE]
> Ready for review, with one caveat worth stating up front: this has run in
> daily use on exactly one machine — AMD RX 9060 XT, two displays, Hyprland
> 0.56.2 with the Lua config parser — and nowhere else. What I could not check
> is listed below; the `wide` / `edid` presets are the part I would most like a
> second opinion on. If you would rather solve this another way, or not at all,
> say so and I will close it.

## What happens

Turning the daemon on over a settled two-display desktop mirrors it to the TV. Nothing had changed and nothing needed to — the desk was already exactly what its saved profile described.

## Why

`ExactStateMatch` compares the saved colour preset against the live one as strings:

```
cm  profile="auto"  live="srgb"  ->  same=false
```

`auto` is a *request*, not a result. Hyprland resolves it and reports back the concrete preset it chose — `srgb` for an ordinary display. So `auto` never equals `srgb`, the exact match never fires, and `BestMatch` is left to pick a winner and apply it over a layout that was already right.

This is not a rare shape: hyprmoncfg writes `cm = auto` itself for any SDR display, so **every profile saved from such a display was unable to recognise the desktop it came from**.

## The change

`colorPresetsAgree` treats `auto` as agreeing with whatever it resolves to, in either direction, while a profile that genuinely asks for `hdr` still refuses to match an SDR display.

Two tests: a table over the preset pairs, and an end-to-end `ExactStateMatch` on the two-display layout this was reported on.

## What it has and has not been through

Since opening this, the fix has sat in my fork's `main` through several days of unrelated work on that one machine. Two things have exercised it harder than ordinary use would:

- **The session now restarts constantly.** I have been building a mode that hands the machine to Steam's gamescope session and back, which tears down and rebuilds the graphical session each time. Every one of those restarts runs the daemon's startup match over the same two-display layout -- exactly the path this fixes -- and the spurious re-apply has not come back once.
- **Two kernels, same hardware.** 7.1.9-arch and 7.2.2 from a distribution kernel, same RX 9060 XT and the same two displays, with the colour presets reported identically by both.

That is daily use on one machine, not verification. Specifically **not** checked:

- **One GPU, one Hyprland version.** Nothing on Intel, NVIDIA, or an older Hyprland. Two kernels is not two drivers -- it is the same amdgpu either way.
- **Only the `auto` / `srgb` / `hdr` presets that machine produces.** I still do not know how Hyprland reports `wide` or `edid` back, so I cannot say whether they need the same treatment — this is the part I would most like a second opinion on.
- **No audit of other `auto` comparisons.** I did not check whether anything else in the codebase depends on `auto` comparing unequal, and a reviewer who knows the codebase would find that faster than I would.
- **No HDR display.** The `hdr` branch of `colorPresetsAgree` is reasoned, not observed.

## What would help

Less a review of the diff than of the premise: is "`auto` agrees with what it resolves to" the right rule, or should the profile store the resolved preset at save time and compare exactly? The second would be a bigger change and I did not want to propose it uninvited.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Q6C5xCnkuZ5zZN9nNEXfwa


